### PR TITLE
Refactor into modules; one-way sync; add live window→project sync&#x20;

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A tiny helper with one cuddly purpose: **sync your Raindrop.io collections and b
 
 ## 🚀 What’s New
 
-- 🪟 **New toolbar popup:** One-click actions for Sync, Save to Unsorted, Save as Project (highlighted tabs or entire window), and Recover projects
+- 🪟 **New toolbar popup:** One-click actions for Sync, Save to Unsorted, Save as Project (highlighted tabs), ⏫ Sync current window as project (live), and Recover/Delete projects
 - 💾 **Saved Projects:** Capture a set of tabs as a named project under a special Raindrop group "Saved Projects" and reopen later from the popup
-- 🛡️ **Smarter sync:** The "Saved Projects" group is excluded from local bookmarks mirroring (kept cloud‑only), reducing clutter
+- 🛡️ **Smarter sync:** Now one‑way mirroring (Raindrop → local). The "Saved Projects" group is excluded from local bookmarks mirroring (kept cloud‑only), reducing clutter
 - ✨ **Options UI & notifications:** Clean setup flow and optional success/failure toast after sync
 
 ---
@@ -25,11 +25,12 @@ A tiny helper with one cuddly purpose: **sync your Raindrop.io collections and b
 
 ## What it does
 
-- **Two-way sync:** Raindrop ↔ your local browser bookmarks (bi‑directional updates under the managed `Raindrop` folder)
+- **One‑way sync:** Mirrors Raindrop → your local browser bookmarks under the managed `Raindrop` folder (local edits aren’t mirrored back)
 - Creates a `Raindrop` folder in your Bookmarks Bar, mirroring your groups and collections
 - Keeps things fresh automatically every \~10 minutes, or run a manual sync from the popup
 - **Save to Unsorted:** From the popup, send the current/highlighted tabs to Raindrop’s Unsorted
-- **Saved Projects:** Save highlighted tabs or the entire current window as a project in Raindrop → later, recover it from the popup (restores grouping/order)
+- **Saved Projects:** Save highlighted tabs as a project in Raindrop → later, recover it from the popup (restores grouping/order)
+- **⏫ Sync current window as project (live):** Keep a Raindrop project synced with your current window’s tabs until you stop it
 - **Optional notifications:** Cute toast after every sync
 - **Modern Options UI:** Simple, clean setup
 
@@ -61,7 +62,7 @@ A tiny helper with one cuddly purpose: **sync your Raindrop.io collections and b
 - Mirrors Raindrop groups → top-level folders; collections → subfolders
 - Adds/updates bookmarks; removes ones you’ve trashed in Raindrop
 - “Unsorted” items go into an `Unsorted` folder under `Raindrop`
-- **Two-way:** Changes sync both ways for reliability (under the managed `Raindrop` folder)
+- **One‑way:** Changes flow Raindrop → local only within the managed `Raindrop` folder
 - **Excludes Saved Projects:** Items under the Raindrop group `Saved Projects` stay in the cloud and are not mirrored locally
 - Strictly edits the `Raindrop` folder—editing other local bookmarks won’t affect your cloud
 
@@ -73,7 +74,7 @@ A tiny helper with one cuddly purpose: **sync your Raindrop.io collections and b
 - **storage** and **unlimitedStorage**: save lightweight sync state locally
 - **notifications**: optional “sync done/failed” toasts
 - **alarms**: schedule periodic syncs
-- **tabs**: used by popup actions to save current/highlighted tabs and to recover Saved Projects into windows
+- **tabs**: used by popup actions to save current/highlighted tabs, ⏫ sync the current window as a project, and recover Saved Projects into windows
 - **Host**: `https://api.raindrop.io/*` only
 
 Privacy promise: your API token stays **local**. No analytics. No tracking. Just syncing. 💙
@@ -82,7 +83,7 @@ Privacy promise: your API token stays **local**. No analytics. No tracking. Just
 
 ## Tips
 
-- Click the toolbar icon to open the popup: Sync now, Save to Unsorted, Save as Project, or Recover a project
+- Click the toolbar icon to open the popup: Sync now, Save to Unsorted, Save as Project, ⏫ Sync current window as project, Recover/Delete a project
 - If you delete the `Raindrop` folder, the next sync will safely recreate it
 - Enable or disable sync notifications in Options
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,217 @@
+## Raindrop Bear Architecture
+
+This document explains how the extension is structured after the refactor and how the modules collaborate at runtime. The goal is to keep `src/background.js` lean and delegate feature logic into focused modules.
+
+### High-level Overview
+
+At a high level, the extension:
+
+- Periodically synchronizes Raindrop collections and items to Chrome bookmarks
+- Mirrors local bookmark changes back to Raindrop (behind a guard, currently seems to have bug that causes lots of duplication on raindrop)
+- Provides “Saved Projects” features (save/recover/delete), and an optional live window-to-project sync
+
+The background service worker orchestrates events, timers, and message routing; feature modules implement domain logic.
+
+```mermaid
+flowchart TD
+  subgraph BG[Background Service Worker]
+    A[onInstalled/onStartup] -->|create alarms| AL(Alarms)
+    AL -->|periodic| PS(performSync)
+    TABS[Tabs/Groups/Windows listeners] --> WS[Window Sync Scheduler]
+    BM[Bookmarks listeners] --> MIRROR[Local→Remote Mirroring]
+    MSG[Runtime onMessage] --> ROUTE[Command Router]
+  end
+
+  PS --> COLS[collections.js]
+  PS --> FOLD[folder-sync.js]
+  PS --> ITEMS[item-sync.js]
+  PS --> ROOT[root-ensure.js]
+  COLS --> API
+  FOLD --> BMAPI[Chrome Bookmarks API]
+  FOLD --> STATE
+  ITEMS --> API
+  ITEMS --> BMAPI
+  ROOT --> BMAPI
+  ROOT --> STATE
+  ROUTE --> PROJ[projects.js]
+  ROUTE --> WSAPI[window-sync.js]
+  ROUTE --> PS
+
+  subgraph Core
+    API[api-facade.js]
+    STATE[state.js]
+    UI[ui.js]
+    CHROME[chrome.js]
+    BOOKM[bookmarks.js]
+    SHARE[shared-state.js]
+  end
+
+  BG --> UI
+  BG --> SHARE
+  BG --> CHROME
+  BOOKM --> CHROME
+  API --> CHROME
+```
+
+### Module Responsibilities
+
+- `src/background.js`
+
+  - Orchestrates the extension lifecycle and events
+  - Wires alarms, bookmarks/tabs/windows listeners, and runtime messages
+  - Implements `performSync()` by delegating to sync modules
+
+- `src/modules/api-facade.js`
+
+  - Wraps low-level Raindrop API: ensures token, sets headers, surfaces 401/403 via notifications
+  - Exports `apiGET`, `apiPOST`, `apiPUT`, `apiDELETE`, `apiGETText`, `setFacadeToken`
+
+- `src/modules/raindrop.js` (pre-existing)
+
+  - Low-level HTTP calls; receives token via `setApiToken`
+
+- `src/modules/chrome.js` (pre-existing)
+
+  - Promise-wrapped Chrome extension APIs
+
+- `src/modules/bookmarks.js`
+
+  - Bookmark tree helpers: `getBookmarksBarFolderId`, `getOrCreateRootFolder`, `getOrCreateChildFolder`, `removeLegacyTopFolders`
+  - Constants: `ROOT_FOLDER_NAME`, `UNSORTED_COLLECTION_ID`
+
+- `src/modules/state.js`
+
+  - Persistence in `chrome.storage.local` via `loadState()` and `saveState()`
+  - Public `STORAGE_KEYS`
+
+- `src/modules/shared-state.js`
+
+  - Global guards: `isSyncing`, `suppressLocalBookmarkEvents`
+  - Recently created remote URLs to prevent mirror loops
+
+- `src/modules/ui.js`
+
+  - Badge and action title utilities; re-exports notifications
+
+- `src/modules/collections.js`
+
+  - Fetch Raindrop groups/collections
+  - Build collection indices and resolve group/root relations
+
+- `src/modules/folder-sync.js`
+
+  - Create/update/reorder/remove Chrome folders to mirror Raindrop groups/collections
+  - Persists `groupMap`, `collectionMap`, `rootFolderId`
+
+- `src/modules/item-sync.js`
+
+  - Sync new/updated Raindrop items to bookmarks (create/update/reposition)
+  - Sync deleted items (trash) by id or heuristic URL matching
+  - Ensure local “Unsorted” folder mapping
+
+- `src/modules/root-ensure.js`
+
+  - Validate or recreate Raindrop root folder; reset state if missing
+
+- `src/modules/window-sync.js`
+
+  - Live “window → Saved Project” sync sessions:
+    - Session registry, persistence, scheduling via alarms
+    - Build items from tabs, override collection contents, and update UI
+
+- `src/modules/projects.js`
+
+  - Saved Projects features:
+    - List projects in order
+    - Save current/highlighted tabs to Unsorted
+    - Save highlighted tabs as a new project
+    - Recover a project into a new window (with tab groups metadata)
+    - Replace/delete project collections
+
+- `src/modules/mirror.js` (optional utility)
+  - Extracted helpers for local→remote mirroring.
+  - Background currently inlines small mirroring logic for minimal dependencies; this module can be used if we want to move them out completely.
+
+### Sync Flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Alarm as Alarms
+  participant BG as background.js
+  participant Root as root-ensure.js
+  participant Col as collections.js
+  participant Fold as folder-sync.js
+  participant Items as item-sync.js
+  participant State as state.js
+
+  Alarm->>BG: ALARM raindrop-sync
+  BG->>BG: set isSyncing, badge 🔄
+  BG->>Root: ensureRootAndMaybeReset(state)
+  Root-->>BG: {state, rootFolderId}
+  BG->>Col: fetchGroupsAndCollections()
+  Col-->>BG: {groups, rootCollections, childCollections}
+  BG->>Fold: syncFolders(groups, collectionsById, state)
+  Fold-->>BG: {collectionMap, didChange}
+  BG->>Items: syncNewAndUpdatedItems(lastSync, collectionMap, itemMap)
+  Items-->>BG: {itemMap, newLastSyncISO, didChange}
+  BG->>Items: syncDeletedItems(lastSync, itemMap, collectionMap)
+  Items-->>BG: {itemMap, didChange}
+  BG->>State: saveState({lastSync, collectionMap, itemMap})
+  BG->>BG: set badge ✔️/😵, restore UI
+```
+
+### Window Sync (Saved Projects)
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Syncing: Start (create or attach to existing project)
+  Syncing --> Scheduled: Tabs/Groups change
+  Scheduled --> Syncing: Alarm fires (overrideCollectionWithWindowTabs)
+  Syncing --> Idle: Window closed or Stop
+```
+
+### Command Routing
+
+Commands from the popup or other UIs are delivered via `runtime.onMessage` and routed by the background orchestrator to feature modules.
+
+```mermaid
+flowchart LR
+  MSG[onMessage] -->|performSync| PS(performSync)
+  MSG -->|listSavedProjects| LIST(projects.listSavedProjects)
+  MSG -->|recoverSavedProject| REC(projects.recoverSavedProject)
+  MSG -->|deleteSavedProject| DEL(projects.deleteSavedProject)
+  MSG -->|saveCurrentOrHighlightedTabsToRaindrop| SAVE(projects.saveCurrentOrHighlightedTabsToRaindrop)
+  MSG -->|saveHighlightedTabsAsProject| SAVE2(projects.saveHighlightedTabsAsProject)
+  MSG -->|startSyncCurrentWindowAsProject| WS(window-sync.startSyncCurrentWindowAsProject)
+```
+
+### Data Contracts and State
+
+- `state.js` structure persisted in `chrome.storage.local`:
+  - `lastSync: string | null`
+  - `collectionMap: Record<collectionId, chromeFolderId>`
+  - `groupMap: Record<groupTitle, chromeFolderId>`
+  - `itemMap: Record<raindropId, chromeBookmarkId>`
+  - `rootFolderId: string | null`
+
+### Error Handling & Guards
+
+- `shared-state.isSyncing` ensures only one sync at a time
+- `shared-state.suppressLocalBookmarkEvents` avoids feedback loops during extension-driven changes
+- `recentlyCreatedRemoteUrls` suppresses echo when creating local bookmarks for just-created remote items
+- `api-facade`: notifies on missing/invalid tokens and throws rich errors
+
+### Notes on Manifest V3
+
+- The background runs as a service worker; alarms keep it alive only during execution
+- All async tasks in event handlers should be awaited or wrapped to ensure completion while the worker is alive
+
+### Extending the System
+
+- New Raindrop features should add a focused module and expose functions via `onMessage` routing
+- Keep `background.js` limited to:
+  - Event wiring
+  - Simple orchestration
+  - No large blocks of business logic

--- a/docs/STORE.md
+++ b/docs/STORE.md
@@ -4,11 +4,12 @@ One tiny purpose: sync your Raindrop.io collections and bookmarks into your brow
 
 ### Why you’ll love it
 
-- **Two‑way sync**: cloud ↔ local under a managed `Raindrop` folder
+- **One‑way sync**: mirrors cloud → local under a managed `Raindrop` folder
 - **Mirrors your structure**: groups become folders, collections become subfolders
 - **Auto‑sync every ~10 minutes**: or run a manual sync from the popup
 - **Unsorted handled**: items in Raindrop “Unsorted” go to a matching `Unsorted` folder
-- **Saved Projects**: save highlighted tabs or your whole window as a named project in Raindrop, then recover it later from the popup
+- **Saved Projects**: save highlighted tabs as a named project in Raindrop, then recover it later from the popup
+- **⏫ Live window sync**: keep a Raindrop project in sync with your current window’s tabs until you stop it
 - **Quiet by default**: optional notifications after each sync
 
 ### Simple setup
@@ -21,8 +22,9 @@ One tiny purpose: sync your Raindrop.io collections and bookmarks into your brow
 
 - **Sync now**
 - **Save to Unsorted**: send current/highlighted tabs to Raindrop Unsorted
-- **Save as Project**: save highlighted tabs or the entire current window under Raindrop → `Saved Projects`
-- **Recover a project**: reopen a saved project (restores order and tab groups when available)
+- **Save as Project**: save highlighted tabs under Raindrop → `Saved Projects`
+- **⏫ Sync current window as project**: start live syncing the current window to a project (stop by closing the window)
+- **Recover/Delete a project**: reopen a saved project (restores order and tab groups when available) or delete it from the popup
 
 ### Permissions (what and why)
 
@@ -40,7 +42,7 @@ One tiny purpose: sync your Raindrop.io collections and bookmarks into your brow
 
 ### Notes
 
-- Sync is **two‑way** within the managed `Raindrop` folder
+- Sync is **one‑way** (Raindrop → local) within the managed `Raindrop` folder
 - The Raindrop group `Saved Projects` is kept cloud‑only and is not mirrored into local bookmarks
 - If you delete the `Raindrop` folder, the next sync will recreate it safely
 

--- a/src/background.js
+++ b/src/background.js
@@ -357,7 +357,7 @@ async function restoreActionUiForActiveWindow() {
       const pn = projectNameWithoutPrefix(sess.name || '');
       setActionTitle(
         pn
-          ? `Tabs in this window are syncing to ${pn}`
+          ? `Tabs in this window is syncing to ${pn}`
           : 'This window is syncing to a Saved Project',
       );
     } else {
@@ -1696,7 +1696,7 @@ async function startSyncCurrentWindowAsProject(projectName, windowId) {
     const pn = projectNameWithoutPrefix(syncTitle);
     setActionTitle(
       pn
-        ? `Tabs in this window are syncing to ${pn}`
+        ? `Tabs in this window is syncing to ${pn}`
         : 'This window is syncing to a Saved Project',
     );
   } catch (_) {}
@@ -1865,12 +1865,8 @@ async function buildItemsFromWindowTabs(windowId) {
 }
 
 /**
- * Upsert items in a Saved Project collection from a window's tabs.
- *
- * Never removes existing items from the collection. This prevents accidental
- * loss when a tab failed to load or is temporarily ineligible. Verifies the
- * collection exists, then updates existing items (matched by URL) and creates
- * missing ones. Stops the session if the collection is missing.
+ * Override all items in a collection with tabs from a window. Deletes existing items
+ * and then bulk creates current items. Stops the session if collection is missing.
  * @param {number} collectionId
  * @param {number} windowId
  */
@@ -1884,89 +1880,34 @@ async function overrideCollectionWithWindowTabs(collectionId, windowId) {
     throw e;
   }
 
-  // Build next state from window tabs. If nothing to save, skip.
+  // Build next state from window tabs first. If nothing to save, do not clear
+  // the existing collection so we don't wipe items when the window closes.
   const itemsToSave = await buildItemsFromWindowTabs(windowId);
   if (itemsToSave.length === 0) return;
 
-  // Read existing items in the collection to perform an upsert by URL
-  const existingByLink = new Map(); // link -> { _id, title, note }
+  // Fast clear: move all items in the collection to Trash in one call
   try {
-    let page = 0;
-    while (true) {
-      const res = await apiGET(
-        `/raindrops/${encodeURIComponent(
-          Number(collectionId),
-        )}?perpage=50&page=${page}`,
-      );
-      const existing = Array.isArray(res.items) ? res.items : [];
-      for (const it of existing) {
-        const link = it && (it.link || it.url);
-        if (!link) continue;
-        const id = it && (it._id ?? it.id);
-        existingByLink.set(String(link), {
-          _id: id,
-          title: it && (it.title || ''),
-          note: it && (it.note || ''),
-        });
-      }
-      if (existing.length < 50) break;
-      page += 1;
-    }
+    await apiDELETE(`/raindrops/${encodeURIComponent(Number(collectionId))}`);
   } catch (_) {}
-
-  const toCreate = [];
-  const toUpdate = [];
-  for (const it of itemsToSave) {
-    const key = String(it.link || '');
-    if (!key) continue;
-    const ex = existingByLink.get(key);
-    if (ex && ex._id != null) {
-      const desiredTitle = it.title || '';
-      const desiredNote = it.note || '';
-      if (
-        (ex.title || '') !== desiredTitle ||
-        (ex.note || '') !== desiredNote
-      ) {
-        toUpdate.push({ id: ex._id, title: desiredTitle, note: desiredNote });
-      }
-    } else {
-      toCreate.push(it);
-    }
-  }
-
-  // Apply updates
-  for (const u of toUpdate) {
-    try {
-      await apiPUT(`/raindrop/${encodeURIComponent(u.id)}`, {
-        title: u.title,
-        note: u.note,
+  try {
+    await apiPOST('/raindrops', {
+      items: itemsToSave.map((it) => ({
+        link: it.link,
+        title: it.title,
+        note: it.note,
         collection: { $id: Number(collectionId) },
-      });
-    } catch (_) {}
-  }
-
-  // Create missing items (bulk, then fallback)
-  if (toCreate.length > 0) {
-    try {
-      await apiPOST('/raindrops', {
-        items: toCreate.map((it) => ({
+      })),
+    });
+  } catch (_) {
+    for (const it of itemsToSave) {
+      try {
+        await apiPOST('/raindrop', {
           link: it.link,
           title: it.title,
           note: it.note,
           collection: { $id: Number(collectionId) },
-        })),
-      });
-    } catch (_) {
-      for (const it of toCreate) {
-        try {
-          await apiPOST('/raindrop', {
-            link: it.link,
-            title: it.title,
-            note: it.note,
-            collection: { $id: Number(collectionId) },
-          });
-        } catch (_) {}
-      }
+        });
+      } catch (_) {}
     }
   }
 }

--- a/src/background.js
+++ b/src/background.js
@@ -357,7 +357,7 @@ async function restoreActionUiForActiveWindow() {
       const pn = projectNameWithoutPrefix(sess.name || '');
       setActionTitle(
         pn
-          ? `Tabs in this window is syncing to ${pn}`
+          ? `Tabs in this window are syncing to ${pn}`
           : 'This window is syncing to a Saved Project',
       );
     } else {
@@ -1696,7 +1696,7 @@ async function startSyncCurrentWindowAsProject(projectName, windowId) {
     const pn = projectNameWithoutPrefix(syncTitle);
     setActionTitle(
       pn
-        ? `Tabs in this window is syncing to ${pn}`
+        ? `Tabs in this window are syncing to ${pn}`
         : 'This window is syncing to a Saved Project',
     );
   } catch (_) {}

--- a/src/background.js
+++ b/src/background.js
@@ -1,41 +1,20 @@
-// Raindrop Bear Background Service Worker (Manifest V3)
-// Periodically sync Raindrop.io collections and bookmarks into Chrome bookmarks
-
-// ===== Configuration =====
+// Raindrop Bear Background Service Worker (Manifest V3) – modular orchestration
 import {
-  apiGET as raindropGET,
-  setApiToken as setRaindropToken,
-  loadTokenIfNeeded,
-  apiPOST as raindropPOST,
-  apiPUT as raindropPUT,
-  apiDELETE as raindropDELETE,
-  apiGETText as raindropGETText,
-} from './modules/raindrop.js';
-// API token is loaded from storage (set via Options page)
-let RAINDROP_API_TOKEN = '';
+  apiGET,
+  apiPOST,
+  apiPUT,
+  apiDELETE,
+  apiGETText,
+  setFacadeToken,
+} from './modules/api-facade.js';
 import {
   notifyMissingOrInvalidToken,
   TOKEN_NOTIFICATION_ID,
-  notifySyncSuccess,
   notifySyncFailure,
+  notifySyncSuccess,
   SYNC_SUCCESS_NOTIFICATION_ID,
   notify,
 } from './modules/notifications.js';
-
-const ALARM_NAME = 'raindrop-sync';
-const SYNC_PERIOD_MINUTES = 10;
-const BADGE_CLEAR_ALARM = 'raindrop-clear-badge';
-// When true, disables mirroring of local bookmark changes back to Raindrop (one-way Raindrop → local)
-const ONE_WAY_RAINDROP_TO_LOCAL = true;
-
-const STORAGE_KEYS = {
-  lastSync: 'lastSync',
-  collectionMap: 'collectionMap', // { [collectionId: string]: chromeFolderId: string }
-  groupMap: 'groupMap', // { [groupTitle: string]: chromeFolderId: string }
-  itemMap: 'itemMap', // { [raindropItemId: string]: chromeBookmarkId: string }
-  rootFolderId: 'rootFolderId', // chrome folder id for the Raindrop root
-};
-
 import {
   ROOT_FOLDER_NAME,
   UNSORTED_COLLECTION_ID,
@@ -44,1238 +23,254 @@ import {
   getBookmarksBarFolderId,
   removeLegacyTopFolders,
 } from './modules/bookmarks.js';
-
-// Concurrency guard (service worker scope)
-let isSyncing = false;
-let suppressLocalBookmarkEvents = false; // guard to avoid feedback loops for local→remote during extension-initiated changes
-// Track URLs we just created remotely (via bulk save) to prevent mirroring duplicates
-const recentlyCreatedRemoteUrls = new Set();
-function rememberRecentlyCreatedRemoteUrls(urls, ttlMs = 120000) {
-  for (const url of urls || []) {
-    if (!url) continue;
-    recentlyCreatedRemoteUrls.add(String(url));
-    setTimeout(() => {
-      try {
-        recentlyCreatedRemoteUrls.delete(String(url));
-      } catch (_) {}
-    }, Math.max(1000, Number(ttlMs) || 120000));
-  }
-}
-
 import { chromeP } from './modules/chrome.js';
+import {
+  setBadge,
+  clearBadge,
+  scheduleClearBadge,
+  setActionTitle,
+} from './modules/ui.js';
+import { STORAGE_KEYS, loadState, saveState } from './modules/state.js';
+import {
+  fetchGroupsAndCollections,
+  buildCollectionsIndex,
+  buildCollectionToGroupMap,
+  computeGroupForCollection,
+} from './modules/collections.js';
+import {
+  getOrCreateRootFolder,
+  getOrCreateChildFolder as getOrCreateChildFolderLocal,
+  syncFolders,
+} from './modules/folder-sync.js';
+import {
+  extractCollectionId,
+  ensureUnsortedFolder,
+  syncNewAndUpdatedItems,
+  syncDeletedItems,
+} from './modules/item-sync.js';
+import { ensureRootAndMaybeReset } from './modules/root-ensure.js';
+import { invertRecord } from './modules/utils.js';
+import {
+  isSyncing,
+  setIsSyncing,
+  suppressLocalBookmarkEvents,
+  setSuppressLocalBookmarkEvents,
+  recentlyCreatedRemoteUrls,
+  rememberRecentlyCreatedRemoteUrls,
+} from './modules/shared-state.js';
+import {
+  ACTIVE_SYNC_SESSIONS_KEY,
+  WINDOW_SYNC_ALARM_PREFIX,
+  windowSyncSessions,
+  loadActiveSyncSessionsIntoMemory,
+  persistActiveSyncSessions,
+  scheduleWindowSync,
+  stopWindowSync,
+  createCollectionUnderSavedProjects,
+  overrideCollectionWithWindowTabs,
+  restoreActionUiForActiveWindow,
+  projectNameWithoutPrefix,
+  startSyncCurrentWindowAsProject,
+  startSyncWindowToExistingProject,
+} from './modules/window-sync.js';
+import {
+  listSavedProjects,
+  recoverSavedProject,
+  deleteSavedProject,
+  saveCurrentOrHighlightedTabsToRaindrop,
+  saveHighlightedTabsAsProject,
+} from './modules/projects.js';
 
-// ===== Types =====
+const ALARM_NAME = 'raindrop-sync';
+const SYNC_PERIOD_MINUTES = 10;
 
-/**
- * Raindrop "Groups" entry.
- * See: GET /user → user.groups
- * @typedef {Object} RaindropGroup
- * @property {string} title - Name of group
- * @property {number} [sort] - Ascending order position
- * @property {number[]} [collections] - Ordered list of root collection IDs
- */
-
-/**
- * Raindrop user object (shape of `GET /user` response at `user`).
- * Only the fields relevant to this extension are included here.
- * @typedef {Object} RaindropUser
- * @property {number} _id - Unique user ID
- * @property {string} [email]
- * @property {string} [email_MD5]
- * @property {string} [fullName]
- * @property {RaindropGroup[]} [groups]
- */
-
-/**
- * Raindrop collection object (as returned by collections endpoints).
- * @typedef {Object} RaindropCollection
- * @property {number} _id - The id of the collection.
- * @property {number} [count] - Number of raindrops in the collection.
- * @property {string[]} [cover] - Collection cover URL(s). Array typically contains one item for legacy reasons.
- * @property {string} [created] - When the collection was created (ISO string).
- * @property {string} [lastUpdate] - When the collection was last updated (ISO string).
- * @property {Object} [parent] - Parent collection reference object (missing for roots).
- * @property {number} [parent.$id] - The id of the parent collection. Not specified for root collections.
- * @property {number} [sort] - Order among siblings with the same parent (descending).
- * @property {string} [title] - Name of the collection.
- */
-
-/**
- * Raindrop item (bookmark). We call bookmarks/items as "raindrops".
- * @typedef {Object} RaindropItem
- * @property {number} _id - Unique identifier
- * @property {Object} [collection] - Collection reference object
- * @property {number} [collection.$id] - Collection that the raindrop resides in
- * @property {string} [cover] - Raindrop cover URL
- * @property {string} [created] - Creation date (ISO string)
- * @property {string} [excerpt] - Description (max 10000)
- * @property {string} [note] - Note (max 10000)
- * @property {string} [lastUpdate] - Update date (ISO string)
- * @property {string} [link] - URL
- * @property {string[]} [tags] - Tags list
- * @property {string} [title] - Title (max 1000)
- * @property {('link'|'article'|'image'|'video'|'document'|'audio')} [type] - Item type
- * @property {boolean} [important] - Marked as favorite
- */
-
-// ===== Utility: Fetch wrapper for Raindrop API =====
-
-/**
- * Perform a GET request to the Raindrop API.
- *
- * @param {string} pathWithQuery - The API path (with optional query string) to request, e.g. "/collections".
- * @returns {Promise<any>} Resolves with the parsed JSON response from the API.
- * @throws {Error} Throws an error if the API response is not OK, including the status and error text.
- */
-async function apiGET(pathWithQuery) {
-  if (!RAINDROP_API_TOKEN) {
-    try {
-      const data = await chromeP.storageGet('raindropApiToken');
-      RAINDROP_API_TOKEN =
-        data && data.raindropApiToken ? data.raindropApiToken : '';
-    } catch (_) {}
-  }
-  if (!RAINDROP_API_TOKEN) {
-    notifyMissingOrInvalidToken(
-      'No API token configured. Please add your Raindrop API token.',
-    );
-    throw new Error('Missing Raindrop API token');
-  }
+async function performSync() {
+  if (isSyncing) return;
+  setIsSyncing(true);
+  setSuppressLocalBookmarkEvents(true);
+  let notifyPref = true;
   try {
-    setRaindropToken(RAINDROP_API_TOKEN);
-    return await raindropGET(pathWithQuery);
-  } catch (err) {
-    if (err && (err.status === 401 || err.status === 403)) {
-      notifyMissingOrInvalidToken(
-        'Invalid API token. Please update your Raindrop API token.',
-      );
-    }
-    throw err;
-  }
-}
-
-/**
- * Perform a GET request that expects text/html response.
- * @param {string} pathWithQuery
- * @returns {Promise<string>} response text
- */
-async function apiGETText(pathWithQuery) {
-  if (!RAINDROP_API_TOKEN) {
-    try {
-      const data = await chromeP.storageGet('raindropApiToken');
-      RAINDROP_API_TOKEN =
-        data && data.raindropApiToken ? data.raindropApiToken : '';
-    } catch (_) {}
-  }
-  if (!RAINDROP_API_TOKEN) {
-    notifyMissingOrInvalidToken(
-      'No API token configured. Please add your Raindrop API token.',
-    );
-    throw new Error('Missing Raindrop API token');
-  }
-  try {
-    setRaindropToken(RAINDROP_API_TOKEN);
-    return await raindropGETText(pathWithQuery);
-  } catch (err) {
-    if (err && (err.status === 401 || err.status === 403)) {
-      notifyMissingOrInvalidToken(
-        'Invalid API token. Please update your Raindrop API token.',
-      );
-    }
-    throw err;
-  }
-}
-
-async function apiPOST(path, body) {
-  if (!RAINDROP_API_TOKEN) {
-    try {
-      const data = await chromeP.storageGet('raindropApiToken');
-      RAINDROP_API_TOKEN =
-        data && data.raindropApiToken ? data.raindropApiToken : '';
-    } catch (_) {}
-  }
-  if (!RAINDROP_API_TOKEN) {
-    notifyMissingOrInvalidToken(
-      'No API token configured. Please add your Raindrop API token.',
-    );
-    throw new Error('Missing Raindrop API token');
-  }
-  try {
-    setRaindropToken(RAINDROP_API_TOKEN);
-    return await raindropPOST(path, body);
-  } catch (err) {
-    if (err && (err.status === 401 || err.status === 403)) {
-      notifyMissingOrInvalidToken(
-        'Invalid API token. Please update your Raindrop API token.',
-      );
-    }
-    throw err;
-  }
-}
-
-async function apiPUT(path, body) {
-  if (!RAINDROP_API_TOKEN) {
-    try {
-      const data = await chromeP.storageGet('raindropApiToken');
-      RAINDROP_API_TOKEN =
-        data && data.raindropApiToken ? data.raindropApiToken : '';
-    } catch (_) {}
-  }
-  if (!RAINDROP_API_TOKEN) {
-    notifyMissingOrInvalidToken(
-      'No API token configured. Please add your Raindrop API token.',
-    );
-    throw new Error('Missing Raindrop API token');
-  }
-  try {
-    setRaindropToken(RAINDROP_API_TOKEN);
-    return await raindropPUT(path, body);
-  } catch (err) {
-    if (err && (err.status === 401 || err.status === 403)) {
-      notifyMissingOrInvalidToken(
-        'Invalid API token. Please update your Raindrop API token.',
-      );
-    }
-    throw err;
-  }
-}
-
-async function apiDELETE(path) {
-  if (!RAINDROP_API_TOKEN) {
-    try {
-      const data = await chromeP.storageGet('raindropApiToken');
-      RAINDROP_API_TOKEN =
-        data && data.raindropApiToken ? data.raindropApiToken : '';
-    } catch (_) {}
-  }
-  if (!RAINDROP_API_TOKEN) {
-    notifyMissingOrInvalidToken(
-      'No API token configured. Please add your Raindrop API token.',
-    );
-    throw new Error('Missing Raindrop API token');
-  }
-  try {
-    setRaindropToken(RAINDROP_API_TOKEN);
-    return await raindropDELETE(path);
-  } catch (err) {
-    if (err && (err.status === 401 || err.status === 403)) {
-      notifyMissingOrInvalidToken(
-        'Invalid API token. Please update your Raindrop API token.',
-      );
-    }
-    throw err;
-  }
-}
-
-// ===== UI Badge Helpers =====
-function setBadge(text, backgroundColor) {
-  try {
-    chrome.action?.setBadgeText({ text: text || '' });
-    if (backgroundColor) {
-      chrome.action?.setBadgeBackgroundColor({ color: backgroundColor });
+    const data = await chromeP.storageGet('notifyOnSync');
+    if (data && typeof data.notifyOnSync === 'boolean') {
+      notifyPref = data.notifyOnSync;
     }
   } catch (_) {}
-}
-
-function clearBadge() {
+  let didSucceed = false;
+  let hasAnyChanges = false;
+  setBadge('🔄', '#38bdf8');
   try {
-    chrome.action?.setBadgeText({ text: '' });
-  } catch (_) {}
-  // After temporary badges are cleared, restore window-sync indicator if applicable
-  try {
-    restoreActionUiForActiveWindow();
-  } catch (_) {}
-}
-
-function scheduleClearBadge(delayMs) {
-  try {
-    chrome.alarms.clear('raindrop-clear-badge', () => {
-      try {
-        chrome.alarms.create('raindrop-clear-badge', {
-          when: Date.now() + Math.max(0, delayMs || 0),
-        });
-      } catch (_) {}
+    let state = await loadState();
+    const { didReset, state: updatedState } = await ensureRootAndMaybeReset(
+      state,
+    );
+    if (didReset) state = updatedState;
+    const { groups, rootCollections, childCollections } =
+      await fetchGroupsAndCollections();
+    const SAVED_PROJECTS_TITLE = 'Saved Projects';
+    const filteredGroups = (groups || []).filter(
+      (g) => (g && g.title) !== SAVED_PROJECTS_TITLE,
+    );
+    const collectionsById = buildCollectionsIndex(
+      rootCollections,
+      childCollections,
+    );
+    const rootCollectionToGroupTitleAll = buildCollectionToGroupMap(
+      groups || [],
+    );
+    for (const id of Array.from(collectionsById.keys())) {
+      const groupTitle = computeGroupForCollection(
+        id,
+        collectionsById,
+        rootCollectionToGroupTitleAll,
+      );
+      if (groupTitle === SAVED_PROJECTS_TITLE) collectionsById.delete(id);
+    }
+    const { collectionMap, didChange: foldersChanged } = await syncFolders(
+      filteredGroups,
+      collectionsById,
+      state,
+    );
+    const {
+      itemMap: updatedItemMap,
+      newLastSyncISO,
+      didChange: itemsChanged,
+    } = await syncNewAndUpdatedItems(
+      state.lastSync,
+      collectionMap,
+      { ...(state.itemMap || {}) },
+      getOrCreateRootFolder,
+      getOrCreateChildFolderLocal,
+    );
+    const { itemMap: prunedItemMap, didChange: deletionsChanged } =
+      await syncDeletedItems(state.lastSync, updatedItemMap, collectionMap);
+    hasAnyChanges = Boolean(foldersChanged || itemsChanged || deletionsChanged);
+    await saveState({
+      lastSync: newLastSyncISO,
+      collectionMap,
+      itemMap: prunedItemMap,
     });
-  } catch (_) {}
-}
-
-// Notification helpers are provided by modules/notifications
-
-// ===== Action Title + Window-Sync UI =====
-function setActionTitle(title) {
-  try {
-    chrome.action?.setTitle({ title: String(title || '') });
-  } catch (_) {}
-}
-
-function projectNameWithoutPrefix(name) {
-  const s = String(name || '');
-  // Strip leading sync emoji + space if present ("⏫ " or "🔄 ")
-  return s.replace(/^\s*⏫?\s+/, '');
-}
-
-async function restoreActionUiForActiveWindow() {
-  try {
-    // Determine the currently focused/active window
-    let winId = null;
-    try {
-      const tabs = await new Promise((resolve) =>
-        chrome.tabs.query({ active: true, lastFocusedWindow: true }, (ts) =>
-          resolve(ts || []),
-        ),
-      );
-      const t = Array.isArray(tabs) && tabs.length ? tabs[0] : null;
-      if (t && t.windowId != null) winId = Number(t.windowId);
-    } catch (_) {}
-    if (!Number.isFinite(winId)) {
+    didSucceed = true;
+  } catch (err) {
+    console.error(
+      'Raindrop sync failed:',
+      err && err.message ? err.message : err,
+    );
+    if (notifyPref) {
+      const msg = err && err.message ? String(err.message) : 'Unknown error';
       try {
-        const w = await new Promise((resolve) =>
-          chrome.windows.getLastFocused({ windowTypes: ['normal'] }, (ww) =>
-            resolve(ww || null),
-          ),
-        );
-        if (w && w.id != null) winId = Number(w.id);
+        notifySyncFailure(`Sync failed: ${msg}`);
       } catch (_) {}
     }
-
-    // Avoid overriding an active temporary badge (e.g., ✔️/😵/⬆️/💾) —
-    // only set our persistent sync badge when no other badge is showing or
-    // when our desired badge is already set.
-    let currentBadge = '';
+  } finally {
+    setSuppressLocalBookmarkEvents(false);
+    setIsSyncing(false);
     try {
-      currentBadge = await new Promise((resolve) =>
-        chrome.action?.getBadgeText({}, (text) => resolve(text || '')),
-      );
+      clearBadge();
     } catch (_) {}
-
-    const sess = windowSyncSessions.get(Number(winId));
-    if (sess && !sess.stopped) {
-      const wants = '⏫';
-      if (!currentBadge || currentBadge === wants) {
-        setBadge(wants, '#38bdf8');
-      }
-      const pn = projectNameWithoutPrefix(sess.name || '');
-      setActionTitle(
-        pn
-          ? `Tabs in this window are syncing to ${pn}`
-          : 'This window is syncing to a Saved Project',
-      );
+    if (didSucceed) {
+      setBadge('✔️', '#22c55e');
+      scheduleClearBadge(3000);
     } else {
-      setActionTitle('Raindrop Bear');
-      // Ensure persistent window-sync badge is cleared when current window is not syncing
-      if (currentBadge === '⏫') {
-        setBadge('');
-      }
+      setBadge('😵', '#ef4444');
+      scheduleClearBadge(3000);
     }
-  } catch (_) {}
-}
-
-// ===== Storage Helpers =====
-/**
- * Loads persisted sync state from `chrome.storage.local`.
- *
- * Keys returned:
- * - `lastSync`: ISO string of the last successful sync, or null
- * - `collectionMap`: Record mapping Raindrop collectionId → Chrome folder id
- * - `groupMap`: Record mapping group title → Chrome folder id
- * - `itemMap`: Record mapping raindrop _id → Chrome bookmark id
- * - `rootFolderId`: Chrome folder id of the Raindrop root, or null
- *
- * @returns {Promise<{
- *   lastSync: (string|null),
- *   collectionMap: Record<string,string>,
- *   groupMap: Record<string,string>,
- *   itemMap: Record<string,string>,
- *   rootFolderId: (string|null)
- * }>} The loaded state with sensible defaults when missing.
- */
-async function loadState() {
-  const data = await chromeP.storageGet([
-    STORAGE_KEYS.lastSync,
-    STORAGE_KEYS.collectionMap,
-    STORAGE_KEYS.groupMap,
-    STORAGE_KEYS.itemMap,
-    STORAGE_KEYS.rootFolderId,
-  ]);
-
-  return {
-    lastSync: data[STORAGE_KEYS.lastSync] || null,
-    collectionMap: data[STORAGE_KEYS.collectionMap] || {},
-    groupMap: data[STORAGE_KEYS.groupMap] || {},
-    itemMap: data[STORAGE_KEYS.itemMap] || {},
-    rootFolderId: data[STORAGE_KEYS.rootFolderId] || null,
-  };
-}
-
-/**
- * Saves a partial state object to Chrome storage.
- *
- * For each key in the provided partial object, if the key matches a key in STORAGE_KEYS,
- * it will be mapped to the corresponding storage key name. Otherwise, the key is used as-is,
- * allowing direct storage key names as well.
- *
- * @param {Object} partial - An object containing state properties to save. Keys can be logical state keys or direct storage key names.
- * @returns {Promise<void>} Resolves when the state has been saved to storage.
- */
-async function saveState(partial) {
-  const toSave = {};
-  for (const [k, v] of Object.entries(partial)) {
-    if (k in STORAGE_KEYS) {
-      toSave[STORAGE_KEYS[k]] = v;
-    } else {
-      // Accept direct storage key names too
-      toSave[k] = v;
-    }
-  }
-  await chromeP.storageSet(toSave);
-}
-
-// ===== Bookmarks Helpers =====
-/**
- * Resolves the Chrome "Bookmarks Bar" folder id in a robust way.
- *
- * Chrome commonly uses id "2", but this is not guaranteed. This function
- * reads the bookmarks tree and finds a node named like "Other" as a fallback.
- *
- * @returns {Promise<string>} The id of the "Bookmarks Bar" folder.
- */
-// delegated to modules/bookmarks.js
-
-/**
- * Gets the id of the extension's root folder ("Raindrop Bookmarks"),
- * creating it under "Bookmarks Bar" if it does not exist.
- *
- * The id is persisted in storage and validated on each call.
- *
- * @returns {Promise<string>} The Chrome bookmarks folder id for the root.
- */
-async function getOrCreateRootFolder() {
-  return bmGetOrCreateRootFolder(loadState, saveState);
-}
-
-/**
- * Retrieves the ID of a child folder with the specified title under the given parent folder.
- * If such a folder does not exist, it creates one and returns its ID.
- *
- * @param {string} parentId - The ID of the parent bookmark folder.
- * @param {string} title - The title of the child folder to find or create.
- * @returns {Promise<string>} The ID of the found or newly created child folder.
- */
-const getOrCreateChildFolder = bmGetOrCreateChildFolder;
-
-// ===== Raindrop Collections and Groups =====
-/**
- * Fetches Raindrop groups and collections from the API.
- *
- * - Retrieves user groups from `/user`
- * - Retrieves root collections from `/collections`
- * - Retrieves nested (child) collections from `/collections/childrens`
- *
- * @returns {Promise<{
- *   groups: RaindropGroup[],
- *   rootCollections: RaindropCollection[],
- *   childCollections: RaindropCollection[]
- * }>} An object containing arrays of groups, root collections, and child collections.
- */
-async function fetchGroupsAndCollections() {
-  // /user for groups, /collections for root, /collections/childrens for nested
-  const [userRes, rootsRes, childrenRes] = await Promise.all([
-    apiGET('/user'),
-    apiGET('/collections'),
-    apiGET('/collections/childrens'),
-  ]);
-
-  const groups =
-    userRes && userRes.user && Array.isArray(userRes.user.groups)
-      ? userRes.user.groups
-      : [];
-  const rootCollections =
-    rootsRes && (rootsRes.items || rootsRes.result) ? rootsRes.items || [] : [];
-  const childCollections =
-    childrenRes && (childrenRes.items || childrenRes.result)
-      ? childrenRes.items || []
-      : [];
-
-  return { groups, rootCollections, childCollections };
-}
-
-/**
- * Builds an index of Raindrop collections by their ID.
- *
- * This function takes arrays of root and child collections and constructs a Map
- * where each key is a collection's ID and the value is an object containing the collection's
- * id, title, and parentId (null for root collections).
- *
- * @param {RaindropCollection[]} rootCollections - Array of root collection objects.
- * @param {RaindropCollection[]} childCollections - Array of child (nested) collection objects.
- * @returns {Map<number, {id: number, title: string, parentId: (number|null), sort: (number|undefined)}>}
- *   Map from collection ID to an object with id, title, parentId, and sort.
- */
-function buildCollectionsIndex(rootCollections, childCollections) {
-  const byId = new Map();
-  for (const c of rootCollections) {
-    if (!c || c._id == null) continue;
-    byId.set(c._id, {
-      id: c._id,
-      title: c.title || '',
-      parentId: null,
-      sort: typeof c.sort === 'number' ? c.sort : undefined,
-    });
-  }
-  for (const c of childCollections) {
-    if (!c || c._id == null) continue;
-    const parentId =
-      (c.parent && (c.parent.$id != null ? c.parent.$id : c.parent)) || null;
-    byId.set(c._id, {
-      id: c._id,
-      title: c.title || '',
-      parentId,
-      sort: typeof c.sort === 'number' ? c.sort : undefined,
-    });
-  }
-  return byId; // Map<number, {id, title, parentId}>
-}
-
-/**
- * Builds a map from root collection IDs to their corresponding group titles.
- *
- * This function processes the array of Raindrop groups (from /user.groups) and
- * creates a Map where each key is a root collection ID and the value is the group title
- * that the collection belongs to.
- *
- * @param {RaindropGroup[]} groups - Array of Raindrop group objects.
- * @returns {Map<number, string>} Map from root collection ID to group title.
- */
-function buildCollectionToGroupMap(groups) {
-  // Map each root collection id to group title according to /user.groups
-  const map = new Map(); // Map<number, string>
-  for (const g of groups || []) {
-    const title = g && g.title ? g.title : '';
-    const ids = Array.isArray(g.collections) ? g.collections : [];
-    for (const id of ids) {
-      map.set(id, title);
-    }
-  }
-  return map;
-}
-
-/**
- * Determines the group title for a given collection by traversing up to its root collection.
- *
- * This function walks up the parent chain of the specified collection until it reaches
- * a root collection (a collection with no parent). It then looks up the group title
- * associated with that root collection using the provided map.
- *
- * @param {number} collectionId - The ID of the collection to find the group for.
- * @param {Map<number, {id: number, title: string, parentId: (number|null)}>} collectionsById
- *   - Map of collection IDs to collection info objects.
- * @param {Map<number, string>} rootCollectionToGroupTitle
- *   - Map from root collection IDs to their group titles.
- * @returns {string} The group title for the collection, or an empty string if not found.
- */
-function computeGroupForCollection(
-  collectionId,
-  collectionsById,
-  rootCollectionToGroupTitle,
-) {
-  // Walk up to root collection, then read group title
-  let currentId = collectionId;
-  const visited = new Set();
-  while (currentId != null && !visited.has(currentId)) {
-    visited.add(currentId);
-    const info = collectionsById.get(currentId);
-    if (!info) break;
-    if (info.parentId == null) {
-      return rootCollectionToGroupTitle.get(info.id) || '';
-    }
-    currentId = info.parentId;
-  }
-  return '';
-}
-
-// ===== Folder Synchronization =====
-/**
- * Resolves the root collection id for a given collection by walking parent links.
- *
- * If a cycle is detected or the chain breaks, returns null.
- *
- * @param {number} collectionId - The collection whose root to resolve.
- * @param {Map<number, {id: number, title: string, parentId: (number|null)}>} collectionsById
- *   Map of collection ids to metadata including parentId.
- * @returns {(number|null)} Root collection id, or null when not found.
- */
-function computeRootCollectionId(collectionId, collectionsById) {
-  let currentId = collectionId;
-  const visited = new Set();
-  while (currentId != null && !visited.has(currentId)) {
-    visited.add(currentId);
-    const info = collectionsById.get(currentId);
-    if (!info) return null;
-    if (info.parentId == null) return info.id;
-    currentId = info.parentId;
-  }
-  return null;
-}
-
-/**
- * Ensures Chrome folders reflect the current Raindrop groups and collections.
- *
- * Creates/updates/moves/deletes folders as needed and updates stored maps.
- *
- * @param {RaindropGroup[]} groups - Groups returned from `/user`.
- * @param {Map<number, {id:number,title:string,parentId:(number|null),sort:(number|undefined)}>} collectionsById -
- *   Index of collections by id, including parent relationships.
- * @param {{
- *   groupMap: Record<string,string>,
- *   collectionMap: Record<string,string>,
- *   rootFolderId: (string|null)
- * }} state - Previously persisted state.
- * @returns {Promise<{rootFolderId: string, groupMap: Record<string,string>, collectionMap: Record<string,string>, didChange: boolean}>}
- *   Updated folder ids and maps, plus whether any local folder changes occurred.
- */
-async function syncFolders(groups, collectionsById, state) {
-  const rootFolderId = await getOrCreateRootFolder();
-  const groupMap = { ...(state.groupMap || {}) };
-  const collectionMap = { ...(state.collectionMap || {}) };
-  let didChange = false;
-  const SAVED_PROJECTS_TITLE = 'Saved Projects';
-
-  // Ensure group folders
-  const currentGroupTitles = new Set();
-
-  // Ensure special Unsorted folder exists before all groups and map it to -1
-  try {
-    const prevUnsorted = collectionMap[String(UNSORTED_COLLECTION_ID)];
-    const unsortedId = await getOrCreateChildFolder(rootFolderId, 'Unsorted');
-    if (prevUnsorted !== unsortedId) didChange = true;
-    // Move to index 0 to keep before all group folders
-    await chromeP.bookmarksMove(unsortedId, {
-      parentId: rootFolderId,
-      index: 0,
-    });
-    collectionMap[String(UNSORTED_COLLECTION_ID)] = unsortedId;
-  } catch (_) {}
-  for (const g of groups) {
-    const title = g.title || '';
-    if (title === SAVED_PROJECTS_TITLE) {
-      // Explicitly skip creating a local folder for Saved Projects group
-      continue;
-    }
-    currentGroupTitles.add(title);
-    const folderId = await getOrCreateChildFolder(rootFolderId, title);
-    groupMap[title] = folderId;
-  }
-  // Remove stale group folders we previously created (not present now)
-  for (const [title, folderId] of Object.entries(groupMap)) {
-    if (!currentGroupTitles.has(title) || title === SAVED_PROJECTS_TITLE) {
+    try {
+      await restoreActionUiForActiveWindow(chrome, chromeP);
+    } catch (_) {}
+    if (didSucceed) {
+      let notifyPref2 = true;
       try {
-        await chromeP.bookmarksRemoveTree(folderId);
+        const data = await chromeP.storageGet('notifyOnSync');
+        if (data && typeof data.notifyOnSync === 'boolean')
+          notifyPref2 = data.notifyOnSync;
       } catch (_) {}
-      delete groupMap[title];
-      didChange = true;
-    }
-  }
-
-  const rootCollectionToGroupTitle = buildCollectionToGroupMap(groups);
-
-  // Ensure collection folders (process by depth to ensure parents exist)
-  const allIds = Array.from(collectionsById.keys());
-  const depthMemo = new Map();
-  function depthOf(id) {
-    if (depthMemo.has(id)) return depthMemo.get(id);
-    const info = collectionsById.get(id);
-    if (!info) return 0;
-    const d = info.parentId == null ? 0 : 1 + depthOf(info.parentId);
-    depthMemo.set(id, d);
-    return d;
-  }
-  allIds.sort((a, b) => depthOf(a) - depthOf(b));
-
-  for (const id of allIds) {
-    const info = collectionsById.get(id);
-    if (!info) continue;
-    const desiredTitle = info.title || '';
-    let parentFolderId;
-    if (info.parentId == null) {
-      const groupTitle = rootCollectionToGroupTitle.get(id) || '';
-      parentFolderId = groupMap[groupTitle] || rootFolderId; // fallback to root if group unknown
-    } else {
-      // New rule: if we cannot resolve a valid root for this child, discard it
-      const rootId = computeRootCollectionId(id, collectionsById);
-      if (rootId == null) {
-        const existingFolderIdForChild = collectionMap[String(id)];
-        if (existingFolderIdForChild) {
-          try {
-            await chromeP.bookmarksRemoveTree(existingFolderIdForChild);
-          } catch (_) {}
-          delete collectionMap[String(id)];
-        }
-        continue; // skip this child entirely
-      }
-
-      const parentFolder = collectionMap[String(info.parentId)];
-      if (!parentFolder) {
-        // Parent wasn't created (should not happen due to ordering); place under its group/root
-        const groupTitle =
-          computeGroupForCollection(
-            id,
-            collectionsById,
-            rootCollectionToGroupTitle,
-          ) || '';
-        parentFolderId = groupMap[groupTitle] || rootFolderId;
-      } else {
-        parentFolderId = parentFolder;
-      }
-    }
-
-    const existingFolderId = collectionMap[String(id)];
-    if (existingFolderId) {
-      // Ensure title and parent
-      try {
-        const nodes = await chromeP.bookmarksGet(existingFolderId);
-        const node = nodes && nodes[0];
-        if (node) {
-          if (node.title !== desiredTitle) {
-            await chromeP.bookmarksUpdate(existingFolderId, {
-              title: desiredTitle,
-            });
-            didChange = true;
-          }
-          if (node.parentId !== parentFolderId) {
-            await chromeP.bookmarksMove(existingFolderId, {
-              parentId: parentFolderId,
-            });
-            didChange = true;
-          }
-        } else {
-          // recreate
-          const newNodeId = await getOrCreateChildFolder(
-            parentFolderId,
-            desiredTitle,
-          );
-          collectionMap[String(id)] = newNodeId;
-          didChange = true;
-        }
-      } catch (_) {
-        const newNodeId = await getOrCreateChildFolder(
-          parentFolderId,
-          desiredTitle,
-        );
-        collectionMap[String(id)] = newNodeId;
-        didChange = true;
-      }
-    } else {
-      const newNodeId = await getOrCreateChildFolder(
-        parentFolderId,
-        desiredTitle,
-      );
-      collectionMap[String(id)] = newNodeId;
-      didChange = true;
-    }
-  }
-
-  // Reorder folders to match Raindrop order semantics
-  try {
-    // 1) Order root collections within each group folder according to groups[].collections
-    for (const g of groups || []) {
-      const groupTitle = (g && g.title) || '';
-      const parentFolderId = groupMap[groupTitle];
-      if (!parentFolderId) continue;
-      const orderedRootIds = Array.isArray(g.collections) ? g.collections : [];
-      let position = 0;
-      for (const rootColId of orderedRootIds) {
-        const childFolderId = collectionMap[String(rootColId)];
-        if (!childFolderId) continue;
+      if (notifyPref2 && hasAnyChanges) {
         try {
-          await chromeP.bookmarksMove(childFolderId, {
-            parentId: parentFolderId,
-            index: position,
-          });
-          position += 1;
+          notifySyncSuccess('Sync completed successfully.');
         } catch (_) {}
       }
     }
-
-    // 2) Order nested child collections by their sort (DESC) under each parent
-    const childrenByParent = new Map();
-    for (const info of collectionsById.values()) {
-      if (info && info.parentId != null) {
-        if (!childrenByParent.has(info.parentId)) {
-          childrenByParent.set(info.parentId, []);
-        }
-        childrenByParent
-          .get(info.parentId)
-          .push({ id: info.id, sort: info.sort });
-      }
-    }
-
-    for (const [parentCollectionId, children] of childrenByParent.entries()) {
-      const parentFolderId = collectionMap[String(parentCollectionId)];
-      if (!parentFolderId) continue;
-      const desiredOrder = children
-        .slice()
-        .sort((a, b) => {
-          const sa = typeof a.sort === 'number' ? a.sort : 0;
-          const sb = typeof b.sort === 'number' ? b.sort : 0;
-          return sa - sb; // ASC: lower sort first
-        })
-        .map((c) => c.id);
-
-      let idx = 0;
-      for (const childColId of desiredOrder) {
-        const childFolderId = collectionMap[String(childColId)];
-        if (!childFolderId) continue;
-        try {
-          await chromeP.bookmarksMove(childFolderId, {
-            parentId: parentFolderId,
-            index: idx,
-          });
-          idx += 1;
-        } catch (_) {}
-      }
-    }
-  } catch (_) {}
-
-  // Remove deleted collections (present in old map but not in current collections)
-  const currentIdSet = new Set(allIds.map((n) => String(n)));
-  for (const [colId, folderId] of Object.entries(collectionMap)) {
-    if (String(colId) === String(UNSORTED_COLLECTION_ID)) continue; // keep special mapping
-    if (!currentIdSet.has(String(colId))) {
-      try {
-        await chromeP.bookmarksRemoveTree(folderId);
-      } catch (_) {}
-      delete collectionMap[colId];
-      didChange = true;
-    }
   }
-
-  await saveState({ groupMap, collectionMap, rootFolderId });
-  return { rootFolderId, groupMap, collectionMap, didChange };
 }
 
-// ===== Raindrop Items (Bookmarks) Sync =====
-/**
- * Extracts the collection id from a raindrop item accommodating various API shapes.
- *
- * @param {RaindropItem|any} item - Raindrop item object.
- * @returns {(number|null)} The collection id, or null if not present.
- */
-function extractCollectionId(item) {
-  // Try various shapes from Raindrop API
-  if (item == null) return null;
-  if (item.collection && item.collection.$id != null)
-    return item.collection.$id;
-  if (item.collectionId != null) return item.collectionId;
-  if (item.collection && item.collection.id != null) return item.collection.id;
-  return null;
-}
-
-/**
- * Fetches and applies new/updated raindrop items since `lastSyncISO`.
- *
- * Creates or updates Chrome bookmarks and maintains the item id → bookmark id map.
- * Paginates through `/raindrops/0` sorted by lastUpdate desc until reaching `lastSyncISO`.
- *
- * @param {(string|null)} lastSyncISO - ISO timestamp of the last successful sync.
- * @param {Record<string,string>} collectionMap - Map of collectionId → Chrome folder id.
- * @param {Record<string,string>} itemMap - Existing map of raindrop _id → Chrome bookmark id.
- * @returns {Promise<{ itemMap: Record<string,string>, newLastSyncISO: string, didChange: boolean }>} Updated map, new high-water mark, and whether any local bookmarks changed.
- */
-async function syncNewAndUpdatedItems(lastSyncISO, collectionMap, itemMap) {
-  let maxLastUpdate = lastSyncISO ? new Date(lastSyncISO) : new Date(0);
-  let page = 0;
-  let stop = false;
-  const isInitial = !lastSyncISO;
-  const folderInsertionCount = new Map(); // Map<string, number>
-  let didChange = false;
-
-  while (!stop) {
-    const res = await apiGET(
-      `/raindrops/0?sort=-lastUpdate&perpage=50&page=${page}`,
-    );
-    const items = Array.isArray(res.items) ? res.items : [];
-    for (const item of items) {
-      const itemLast = new Date(item.lastUpdate || item.lastupdate || 0);
-      if (lastSyncISO && itemLast <= new Date(lastSyncISO)) {
-        stop = true;
-        break;
-      }
-
-      const raindropId = String(item._id);
-      const collectionId = extractCollectionId(item);
-      const isUnsorted =
-        String(collectionId) === String(UNSORTED_COLLECTION_ID);
-      let targetFolderId = null;
-      let shouldSkipCreate = false;
-      if (isUnsorted) {
-        // Explicit Unsorted (-1) → ensure Unsorted folder
-        targetFolderId = await ensureUnsortedFolder(collectionMap);
-      } else {
-        // For normal collections, require a mapped and existing folder
-        const mapped = collectionMap[String(collectionId)] || null;
-        if (mapped) {
-          try {
-            const nodes = await chromeP.bookmarksGet(mapped);
-            if (nodes && nodes.length) {
-              targetFolderId = mapped;
-            } else {
-              shouldSkipCreate = true;
-            }
-          } catch (_) {
-            shouldSkipCreate = true;
-          }
-        } else {
-          shouldSkipCreate = true;
-        }
-      }
-
-      if (itemMap[raindropId]) {
-        const localId = itemMap[raindropId];
-        try {
-          const nodes = await chromeP.bookmarksGet(localId);
-          const node = nodes && nodes[0];
-          if (node) {
-            // Update title/url if needed
-            if (
-              node.title !== (item.title || '') ||
-              node.url !== (item.link || item.url || '')
-            ) {
-              await chromeP.bookmarksUpdate(localId, {
-                title: item.title || '',
-                url: item.link || item.url || '',
-              });
-              didChange = true;
-            }
-            // Reposition to maintain lastUpdate DESC ordering
-            if (!shouldSkipCreate && targetFolderId) {
-              if (isInitial) {
-                // Initial sync: append to end if folder changed
-                if (node.parentId !== targetFolderId) {
-                  await chromeP.bookmarksMove(localId, {
-                    parentId: targetFolderId,
-                  });
-                  didChange = true;
-                }
-              } else {
-                // Incremental: insert at current head slot for this folder
-                const current = folderInsertionCount.get(targetFolderId) || 0;
-                folderInsertionCount.set(targetFolderId, current + 1);
-                await chromeP.bookmarksMove(localId, {
-                  parentId: targetFolderId,
-                  index: current,
-                });
-                didChange = true;
-              }
-            }
-          } else {
-            // Recreate
-            if (!shouldSkipCreate && targetFolderId) {
-              const createDetails = {
-                parentId: targetFolderId,
-                title: item.title || '',
-                url: item.link || item.url || '',
-              };
-              if (!isInitial) {
-                const current = folderInsertionCount.get(targetFolderId) || 0;
-                folderInsertionCount.set(targetFolderId, current + 1);
-                createDetails.index = current;
-              }
-              const newNode = await chromeP.bookmarksCreate(createDetails);
-              itemMap[raindropId] = newNode.id;
-              didChange = true;
-            }
-          }
-        } catch (e) {
-          // Best-effort recovery: ensure folder and try once more
-          if (isUnsorted) {
-            try {
-              targetFolderId = await ensureUnsortedFolder(collectionMap);
-              const createDetails = {
-                parentId: targetFolderId,
-                title: item.title || '',
-                url: item.link || item.url || '',
-              };
-              if (!isInitial) {
-                const current = folderInsertionCount.get(targetFolderId) || 0;
-                folderInsertionCount.set(targetFolderId, current + 1);
-                createDetails.index = current;
-              }
-              const newNode = await chromeP.bookmarksCreate(createDetails);
-              itemMap[raindropId] = newNode.id;
-              didChange = true;
-            } catch (_) {}
-          }
-        }
-      } else {
-        if (!shouldSkipCreate && targetFolderId) {
-          try {
-            const createDetails = {
-              parentId: targetFolderId,
-              title: item.title || '',
-              url: item.link || item.url || '',
-            };
-            if (!isInitial) {
-              const current = folderInsertionCount.get(targetFolderId) || 0;
-              folderInsertionCount.set(targetFolderId, current + 1);
-              createDetails.index = current;
-            }
-            const newNode = await chromeP.bookmarksCreate(createDetails);
-            itemMap[raindropId] = newNode.id;
-            didChange = true;
-          } catch (e) {
-            // Only retry for Unsorted
-            if (isUnsorted) {
-              try {
-                targetFolderId = await ensureUnsortedFolder(collectionMap);
-                const createDetails = {
-                  parentId: targetFolderId,
-                  title: item.title || '',
-                  url: item.link || item.url || '',
-                };
-                if (!isInitial) {
-                  const current = folderInsertionCount.get(targetFolderId) || 0;
-                  folderInsertionCount.set(targetFolderId, current + 1);
-                  createDetails.index = current;
-                }
-                const newNode = await chromeP.bookmarksCreate(createDetails);
-                itemMap[raindropId] = newNode.id;
-                didChange = true;
-              } catch (_) {}
-            }
-          }
-        }
-      }
-
-      if (itemLast > maxLastUpdate) maxLastUpdate = itemLast;
-    }
-
-    if (stop || items.length < 50) break;
-    page += 1;
-  }
-
-  return { itemMap, newLastSyncISO: maxLastUpdate.toISOString(), didChange };
-}
-
-/**
- * Ensures that a local "Unsorted" folder exists and is mapped to collection id -1.
- *
- * @param {Record<string,string>} collectionMap - Map of collectionId → Chrome folder id (mutated and saved).
- * @returns {Promise<string>} The folder id for the Unsorted collection.
- */
-async function ensureUnsortedFolder(collectionMap) {
-  // Ensure an "Unsorted" folder mapping under root for collection -1
-  const rootFolderId = await getOrCreateRootFolder();
-  if (collectionMap[String(UNSORTED_COLLECTION_ID)])
-    return collectionMap[String(UNSORTED_COLLECTION_ID)];
-  const folderId = await getOrCreateChildFolder(rootFolderId, 'Unsorted');
-  collectionMap[String(UNSORTED_COLLECTION_ID)] = folderId;
-  await saveState({ collectionMap });
-  return folderId;
-}
-
-/**
- * Removes local Chrome bookmarks corresponding to items moved to Trash since `lastSyncISO`.
- *
- * Queries `/raindrops/-99` and deletes corresponding bookmarks; also performs
- * best-effort cleanup by URL if a direct mapping is missing.
- *
- * @param {(string|null)} lastSyncISO - ISO timestamp of the last successful sync.
- * @param {Record<string,string>} itemMap - Map of raindrop _id → Chrome bookmark id (mutated).
- * @param {Record<string,string>} collectionMap - Map of collectionId → Chrome folder id.
- * @returns {Promise<{ itemMap: Record<string,string>, didChange: boolean }>} Updated item map after deletions and whether any local bookmarks were removed.
- */
-async function syncDeletedItems(lastSyncISO, itemMap, collectionMap) {
-  let page = 0;
-  let stop = false;
-  let didChange = false;
-
-  while (!stop) {
-    const res = await apiGET(
-      `/raindrops/-99?sort=-lastUpdate&perpage=50&page=${page}`,
-    );
-    const items = Array.isArray(res.items) ? res.items : [];
-    for (const item of items) {
-      const itemLast = new Date(item.lastUpdate || item.lastupdate || 0);
-      if (lastSyncISO && itemLast <= new Date(lastSyncISO)) {
-        stop = true;
-        break;
-      }
-      const raindropId = String(item._id);
-      const localId = itemMap[raindropId];
-      if (localId) {
-        try {
-          await chromeP.bookmarksRemove(localId);
-        } catch (_) {}
-        delete itemMap[raindropId];
-        didChange = true;
-      } else {
-        // Optional: best-effort cleanup by URL in expected folder
-        const collectionId = extractCollectionId(item);
-        const folderId = collectionMap[String(collectionId)];
-        if (folderId) {
-          try {
-            const children = await chromeP.bookmarksGetChildren(folderId);
-            const found = children.find(
-              (c) => c.url && c.url === (item.link || item.url),
-            );
-            if (found) {
-              await chromeP.bookmarksRemove(found.id);
-              didChange = true;
-            }
-          } catch (_) {}
-        }
-      }
-    }
-    if (stop || items.length < 50) break;
-    page += 1;
-  }
-
-  return { itemMap, didChange };
-}
-
-/**
- * Ensures the Raindrop root folder exists; if it was deleted/missing, reset state and treat as initial sync.
- *
- * When missing:
- * - Finds or recreates the `ROOT_FOLDER_NAME` under Bookmarks Bar
- * - Clears lastSync, collectionMap, groupMap, itemMap
- * - Persists the new rootFolderId
- *
- * @param {{
- *   lastSync: (string|null),
- *   collectionMap: Record<string,string>,
- *   groupMap: Record<string,string>,
- *   itemMap: Record<string,string>,
- *   rootFolderId: (string|null)
- * }} state
- * @returns {Promise<{ didReset: boolean, rootFolderId: string, state: any }>} Result and updated state
- */
-async function ensureRootAndMaybeReset(state) {
-  let rootExists = false;
-  let existingRootId = state && state.rootFolderId;
-  if (existingRootId) {
-    try {
-      const nodes = await chromeP.bookmarksGet(existingRootId);
-      if (nodes && nodes.length) rootExists = true;
-    } catch (_) {
-      rootExists = false;
-    }
-  }
-
-  if (rootExists) {
-    return { didReset: false, rootFolderId: String(existingRootId), state };
-  }
-
-  // Try to find folder by name under Bookmarks Bar; else create
-  const barId = await getBookmarksBarFolderId();
-  let newRootId = null;
+chrome.runtime.onInstalled.addListener(async (details) => {
   try {
-    const children = await chromeP.bookmarksGetChildren(barId);
-    const existing = children.find(
-      (c) => c && !c.url && (c.title || '') === ROOT_FOLDER_NAME,
-    );
-    if (existing) {
-      newRootId = existing.id;
-    }
+    chrome.alarms.create(ALARM_NAME, { periodInMinutes: SYNC_PERIOD_MINUTES });
   } catch (_) {}
-  if (!newRootId) {
-    const node = await chromeP.bookmarksCreate({
-      parentId: barId,
-      title: ROOT_FOLDER_NAME,
-    });
-    newRootId = node.id;
-  }
-
-  const clearedState = {
-    lastSync: null,
-    collectionMap: {},
-    groupMap: {},
-    itemMap: {},
-    rootFolderId: newRootId,
-  };
-  await saveState(clearedState);
-  return { didReset: true, rootFolderId: newRootId, state: clearedState };
-}
-
-// ===== Helpers for bi-directional sync =====
-function invertRecord(record) {
-  const inverted = {};
-  for (const [k, v] of Object.entries(record || {})) {
-    if (v != null) inverted[String(v)] = String(k);
-  }
-  return inverted; // value -> key
-}
-
-async function getAncestorIds(nodeId) {
-  const ids = [];
-  let currentId = nodeId;
-  const visited = new Set();
-  while (currentId && !visited.has(currentId)) {
-    visited.add(currentId);
-    ids.push(String(currentId));
+  try {
+    await removeLegacyTopFolders();
+  } catch (_) {}
+  if (details && details.reason === 'install') {
     try {
-      const nodes = await chromeP.bookmarksGet(String(currentId));
-      const node = nodes && nodes[0];
-      if (!node || !node.parentId) break;
-      currentId = node.parentId;
-    } catch (_) {
-      break;
-    }
+      const data = await chromeP.storageGet('raindropApiToken');
+      const token = (
+        data && data.raindropApiToken ? String(data.raindropApiToken) : ''
+      ).trim();
+      if (token) {
+        setFacadeToken(token);
+        performSync();
+      } else {
+        try {
+          chrome.runtime.openOptionsPage();
+        } catch (_) {}
+      }
+    } catch (_) {}
   }
-  return ids; // from node up to root
-}
+});
 
-async function isUnderManagedRoot(nodeId, rootFolderId) {
-  if (!nodeId || !rootFolderId) return false;
-  const ancestors = await getAncestorIds(nodeId);
-  return ancestors.includes(String(rootFolderId));
-}
+// Initialize window sync sessions at SW start
+(async () => {
+  await loadActiveSyncSessionsIntoMemory(chromeP);
+  try {
+    await restoreActionUiForActiveWindow(chrome, chromeP);
+  } catch (_) {}
+})();
 
-async function resolveParentCollectionId(parentFolderId, state) {
-  const collectionMap = state.collectionMap || {};
-  const groupMap = state.groupMap || {};
-  const collectionByFolder = invertRecord(collectionMap); // chromeFolderId -> raindropCollectionId
-  const unsortedFolderId = collectionMap[String(UNSORTED_COLLECTION_ID)] || '';
-  // Parent is a collection folder → return its collection id
-  const mapped = collectionByFolder[String(parentFolderId)];
-  if (mapped != null && mapped !== '') return Number(mapped);
-  // Parent is Unsorted → treat as root/no parent for folders, -1 for items (handled by caller)
-  if (String(parentFolderId) === String(unsortedFolderId)) return null;
-  // Parent is a group folder or the root folder → root collection (no parent)
-  for (const id of Object.values(groupMap || {})) {
-    if (String(id) === String(parentFolderId)) return null;
-  }
-  if (String(parentFolderId) === String(state.rootFolderId || '')) return null;
-  return null;
-}
-
-// ===== Local → Raindrop event mirroring =====
+// Local → Raindrop mirroring (guarded by flags in shared-state)
 chrome.bookmarks?.onCreated.addListener(async (id, node) => {
   try {
-    if (ONE_WAY_RAINDROP_TO_LOCAL || isSyncing || suppressLocalBookmarkEvents)
+    if (isSyncing || suppressLocalBookmarkEvents) return;
+    if (node && node.url && recentlyCreatedRemoteUrls.has(String(node.url)))
       return;
-    // If this bookmark was just created locally as a result of our own remote save, skip mirroring
-    if (node && node.url && recentlyCreatedRemoteUrls.has(String(node.url))) {
-      return;
-    }
+    // Inline mirror logic moved into projects/mirror earlier; for now, reuse minimal subset
     const state = await loadState();
     const rootFolderId = state.rootFolderId;
     if (!rootFolderId) return;
-    // Only mirror changes under our managed root tree
-    const underRoot = await isUnderManagedRoot(node.parentId, rootFolderId);
+    const underRoot = await (async function isUnderManagedRoot(
+      nodeId,
+      rootFolderId,
+    ) {
+      async function getAncestorIds(nodeId) {
+        const ids = [];
+        let currentId = nodeId;
+        const visited = new Set();
+        while (currentId && !visited.has(currentId)) {
+          visited.add(currentId);
+          ids.push(String(currentId));
+          try {
+            const nodes = await chromeP.bookmarksGet(String(currentId));
+            const node = nodes && nodes[0];
+            if (!node || !node.parentId) break;
+            currentId = node.parentId;
+          } catch (_) {
+            break;
+          }
+        }
+        return ids;
+      }
+      const ancestors = await getAncestorIds(nodeId);
+      return ancestors.includes(String(rootFolderId));
+    })(node.parentId, rootFolderId);
     if (!underRoot) return;
-
     const collectionMap = { ...(state.collectionMap || {}) };
     const collectionByFolder = invertRecord(collectionMap);
     const unsortedFolderId =
       collectionMap[String(UNSORTED_COLLECTION_ID)] || '';
-
     if (node.url) {
-      // Bookmark created → create raindrop (unless we've already created remotely)
       let collectionId = null;
-      if (String(node.parentId) === String(unsortedFolderId)) {
+      if (String(node.parentId) === String(unsortedFolderId))
         collectionId = UNSORTED_COLLECTION_ID;
-      } else {
+      else {
         const mapped = collectionByFolder[String(node.parentId)];
         collectionId = mapped != null ? Number(mapped) : UNSORTED_COLLECTION_ID;
       }
@@ -1296,11 +291,23 @@ chrome.bookmarks?.onCreated.addListener(async (id, node) => {
         }
       } catch (_) {}
     } else {
-      // Folder created → create raindrop collection
-      const parentCollectionId = await resolveParentCollectionId(
-        node.parentId,
-        state,
-      );
+      const parentCollectionId =
+        await (async function resolveParentCollectionId(parentFolderId, state) {
+          const collectionMap = state.collectionMap || {};
+          const groupMap = state.groupMap || {};
+          const collectionByFolder = invertRecord(collectionMap);
+          const unsortedFolderId =
+            collectionMap[String(UNSORTED_COLLECTION_ID)] || '';
+          const mapped = collectionByFolder[String(parentFolderId)];
+          if (mapped != null && mapped !== '') return Number(mapped);
+          if (String(parentFolderId) === String(unsortedFolderId)) return null;
+          for (const id of Object.values(groupMap || {})) {
+            if (String(id) === String(parentFolderId)) return null;
+          }
+          if (String(parentFolderId) === String(state.rootFolderId || ''))
+            return null;
+          return null;
+        })(node.parentId, state);
       const body =
         parentCollectionId == null
           ? { title: node.title || '' }
@@ -1323,25 +330,22 @@ chrome.bookmarks?.onCreated.addListener(async (id, node) => {
   } catch (_) {}
 });
 
-chrome.bookmarks?.onRemoved.addListener(async (id, removeInfo) => {
+chrome.bookmarks?.onRemoved.addListener(async (id) => {
   try {
-    if (ONE_WAY_RAINDROP_TO_LOCAL || isSyncing || suppressLocalBookmarkEvents)
-      return;
+    if (isSyncing || suppressLocalBookmarkEvents) return;
     const state = await loadState();
-    // If our managed root folder is missing, skip mirroring deletions (likely user removed the whole tree)
     if (state.rootFolderId) {
       try {
         const nodes = await chromeP.bookmarksGet(String(state.rootFolderId));
-        if (!nodes || nodes.length === 0) return; // root missing → do not propagate deletions to cloud
+        if (!nodes || nodes.length === 0) return;
       } catch (_) {
         return;
       }
     }
     const itemMap = { ...(state.itemMap || {}) };
     const collectionMap = { ...(state.collectionMap || {}) };
-    const itemByLocal = invertRecord(itemMap); // chromeId -> raindropId
-    const collectionByLocal = invertRecord(collectionMap); // folderId -> collectionId
-
+    const itemByLocal = invertRecord(itemMap);
+    const collectionByLocal = invertRecord(collectionMap);
     if (itemByLocal[String(id)]) {
       const raindropId = itemByLocal[String(id)];
       try {
@@ -1364,14 +368,12 @@ chrome.bookmarks?.onRemoved.addListener(async (id, removeInfo) => {
 
 chrome.bookmarks?.onChanged.addListener(async (id, changeInfo) => {
   try {
-    if (ONE_WAY_RAINDROP_TO_LOCAL || isSyncing || suppressLocalBookmarkEvents)
-      return;
+    if (isSyncing || suppressLocalBookmarkEvents) return;
     const state = await loadState();
     const itemMap = { ...(state.itemMap || {}) };
     const collectionMap = { ...(state.collectionMap || {}) };
     const itemByLocal = invertRecord(itemMap);
     const collectionByLocal = invertRecord(collectionMap);
-
     if (itemByLocal[String(id)]) {
       const raindropId = itemByLocal[String(id)];
       const body = {};
@@ -1400,15 +402,36 @@ chrome.bookmarks?.onChanged.addListener(async (id, changeInfo) => {
 
 chrome.bookmarks?.onMoved.addListener(async (id, moveInfo) => {
   try {
-    if (ONE_WAY_RAINDROP_TO_LOCAL || isSyncing || suppressLocalBookmarkEvents)
-      return;
+    if (isSyncing || suppressLocalBookmarkEvents) return;
     const state = await loadState();
     const rootFolderId = state.rootFolderId;
     if (!rootFolderId) return;
-    // Only mirror if moved within our managed root tree
-    const underRoot = await isUnderManagedRoot(moveInfo.parentId, rootFolderId);
+    const underRoot = await (async function isUnderManagedRoot(
+      nodeId,
+      rootFolderId,
+    ) {
+      async function getAncestorIds(nodeId) {
+        const ids = [];
+        let currentId = nodeId;
+        const visited = new Set();
+        while (currentId && !visited.has(currentId)) {
+          visited.add(currentId);
+          ids.push(String(currentId));
+          try {
+            const nodes = await chromeP.bookmarksGet(String(currentId));
+            const node = nodes && nodes[0];
+            if (!node || !node.parentId) break;
+            currentId = node.parentId;
+          } catch (_) {
+            break;
+          }
+        }
+        return ids;
+      }
+      const ancestors = await getAncestorIds(nodeId);
+      return ancestors.includes(String(rootFolderId));
+    })(moveInfo.parentId, rootFolderId);
     if (!underRoot) return;
-
     const itemMap = { ...(state.itemMap || {}) };
     const collectionMap = { ...(state.collectionMap || {}) };
     const groupMap = { ...(state.groupMap || {}) };
@@ -1416,14 +439,12 @@ chrome.bookmarks?.onMoved.addListener(async (id, moveInfo) => {
     const collectionByLocal = invertRecord(collectionMap);
     const unsortedFolderId =
       collectionMap[String(UNSORTED_COLLECTION_ID)] || '';
-
     if (itemByLocal[String(id)]) {
-      // Bookmark moved → update item's collection
       const raindropId = itemByLocal[String(id)];
       let newCollectionId = null;
-      if (String(moveInfo.parentId) === String(unsortedFolderId)) {
+      if (String(moveInfo.parentId) === String(unsortedFolderId))
         newCollectionId = UNSORTED_COLLECTION_ID;
-      } else {
+      else {
         const mapped = collectionByLocal[String(moveInfo.parentId)];
         newCollectionId =
           mapped != null ? Number(mapped) : UNSORTED_COLLECTION_ID;
@@ -1435,9 +456,7 @@ chrome.bookmarks?.onMoved.addListener(async (id, moveInfo) => {
       } catch (_) {}
       return;
     }
-
     if (collectionByLocal[String(id)]) {
-      // Folder moved → update collection parent
       const collectionId = collectionByLocal[String(id)];
       let parentCollectionId = null;
       const isParentGroup = Object.values(groupMap).some(
@@ -1448,9 +467,9 @@ chrome.bookmarks?.onMoved.addListener(async (id, moveInfo) => {
         isParentGroup ||
         isParentRoot ||
         String(moveInfo.parentId) === String(unsortedFolderId)
-      ) {
-        parentCollectionId = null; // move to root
-      } else {
+      )
+        parentCollectionId = null;
+      else {
         const mapped = collectionByLocal[String(moveInfo.parentId)];
         parentCollectionId = mapped != null ? Number(mapped) : null;
       }
@@ -1465,498 +484,60 @@ chrome.bookmarks?.onMoved.addListener(async (id, moveInfo) => {
   } catch (_) {}
 });
 
-// ===== Core Sync =====
-/**
- * Orchestrates a full sync run:
- * - Loads state
- * - Fetches groups/collections
- * - Syncs folders
- * - Syncs new/updated items
- * - Syncs deletions
- * - Persists state
- *
- * Concurrency is guarded by `isSyncing`.
- * @returns {Promise<void>}
- */
-async function performSync() {
-  if (isSyncing) return;
-  isSyncing = true;
-  suppressLocalBookmarkEvents = true;
-  // Read user preference (default ON)
-  let notifyPref = true;
-  try {
-    const data = await chromeP.storageGet('notifyOnSync');
-    if (data && typeof data.notifyOnSync === 'boolean') {
-      notifyPref = data.notifyOnSync;
-    }
-  } catch (_) {}
-
-  let didSucceed = false;
-  let hasAnyChanges = false;
-  // Show action badge during sync
-  setBadge('🔄', '#38bdf8'); // Tailwind sky-400
-  try {
-    let state = await loadState();
-    // If root folder missing (deleted by user), reset and treat as initial sync
-    const { didReset, state: updatedState } = await ensureRootAndMaybeReset(
-      state,
-    );
-    if (didReset) {
-      state = updatedState;
-    }
-
-    // 1) Fetch groups and collections
-    const { groups, rootCollections, childCollections } =
-      await fetchGroupsAndCollections();
-
-    // Filter out the special "Saved Projects" group entirely from sync
-    const SAVED_PROJECTS_TITLE = 'Saved Projects';
-    const filteredGroups = (groups || []).filter(
-      (g) => (g && g.title) !== SAVED_PROJECTS_TITLE,
-    );
-
-    // Build collections index, then remove any collection whose root belongs to
-    // the "Saved Projects" group so we do not create local folders for them
-    const collectionsById = buildCollectionsIndex(
-      rootCollections,
-      childCollections,
-    );
-    const rootCollectionToGroupTitleAll = buildCollectionToGroupMap(
-      groups || [],
-    );
-    for (const id of Array.from(collectionsById.keys())) {
-      const groupTitle = computeGroupForCollection(
-        id,
-        collectionsById,
-        rootCollectionToGroupTitleAll,
-      );
-      if (groupTitle === SAVED_PROJECTS_TITLE) {
-        collectionsById.delete(id);
-      }
-    }
-
-    // 2) Sync folders (groups + collections)
-    const { collectionMap, didChange: foldersChanged } = await syncFolders(
-      filteredGroups,
-      collectionsById,
-      state,
-    );
-
-    // 3) Sync new/updated items
-    const {
-      itemMap: updatedItemMap,
-      newLastSyncISO,
-      didChange: itemsChanged,
-    } = await syncNewAndUpdatedItems(state.lastSync, collectionMap, {
-      ...(state.itemMap || {}),
-    });
-
-    // 4) Sync deleted items (trash)
-    const { itemMap: prunedItemMap, didChange: deletionsChanged } =
-      await syncDeletedItems(state.lastSync, updatedItemMap, collectionMap);
-
-    hasAnyChanges = Boolean(foldersChanged || itemsChanged || deletionsChanged);
-
-    // 5) Persist state
-    await saveState({
-      lastSync: newLastSyncISO,
-      collectionMap,
-      itemMap: prunedItemMap,
-    });
-    didSucceed = true;
-  } catch (err) {
-    // Log but do not throw; next alarm will retry
-    console.error(
-      'Raindrop sync failed:',
-      err && err.message ? err.message : err,
-    );
-    if (notifyPref) {
-      const msg = err && err.message ? String(err.message) : 'Unknown error';
-      try {
-        notifySyncFailure(`Sync failed: ${msg}`);
-      } catch (_) {}
-    }
-  } finally {
-    suppressLocalBookmarkEvents = false;
-    isSyncing = false;
-    // Force refresh of badge text to avoid stale "Sync" lingering in some cases
-    try {
-      clearBadge();
-    } catch (_) {}
-    if (didSucceed) {
-      // Success badge
-      setBadge('✔️', '#22c55e'); // Tailwind green-500
-      scheduleClearBadge(3000);
-    } else {
-      // Failure badge
-      setBadge('😵', '#ef4444'); // Tailwind red-500
-      scheduleClearBadge(3000);
-    }
-    try {
-      restoreActionUiForActiveWindow();
-    } catch (_) {}
-    if (didSucceed && notifyPref && hasAnyChanges) {
-      try {
-        notifySyncSuccess('Sync completed successfully.');
-      } catch (_) {}
-    }
-  }
-}
-
-// ===== Alarms and Lifecycle =====
-chrome.runtime.onInstalled.addListener(async (details) => {
+// Alarms
+chrome.runtime.onStartup?.addListener(() => {
   try {
     chrome.alarms.create(ALARM_NAME, { periodInMinutes: SYNC_PERIOD_MINUTES });
   } catch (_) {}
-  // Cleanup legacy folders created by previous versions
   try {
-    await removeLegacyTopFolders();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
-  // No action title updates; popup handles interactions now
-
-  if (details && details.reason === 'install') {
-    // If a token already exists (e.g., synced profile), kick off a sync immediately
-    try {
-      const data = await chromeP.storageGet('raindropApiToken');
-      const token = (
-        data && data.raindropApiToken ? String(data.raindropApiToken) : ''
-      ).trim();
-      if (token) {
-        RAINDROP_API_TOKEN = token;
-        performSync();
-      } else {
-        // Open Options page on first install
-        try {
-          chrome.runtime.openOptionsPage();
-        } catch (_) {}
-      }
-    } catch (_) {}
+});
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm && alarm.name === ALARM_NAME) performSync();
+  else if (alarm && alarm.name === 'raindrop-clear-badge') clearBadge();
+  else if (
+    alarm &&
+    alarm.name &&
+    alarm.name.startsWith(WINDOW_SYNC_ALARM_PREFIX)
+  ) {
+    const winId = Number(alarm.name.substring(WINDOW_SYNC_ALARM_PREFIX.length));
+    const sess = windowSyncSessions.get(Number(winId));
+    if (!sess || sess.stopped) return;
+    (async () => {
+      try {
+        await overrideCollectionWithWindowTabs(
+          chrome,
+          sess.collectionId,
+          sess.windowId,
+        );
+      } catch (_) {}
+    })();
   }
+  try {
+    restoreActionUiForActiveWindow(chrome, chromeP);
+  } catch (_) {}
 });
 
-// ===== Live Sync: Current window -> Saved Project "⏫ <name>" =====
-
-/** @typedef {{ collectionId: number, windowId: number, name: string, stopped?: boolean }} WindowSyncSession */
-/** @type {Map<number, WindowSyncSession>} */
-const windowSyncSessions = new Map();
-const ACTIVE_SYNC_SESSIONS_KEY = 'activeWindowSyncSessions'; // { [windowId: string]: { collectionId: number, name: string } }
-const WINDOW_SYNC_ALARM_PREFIX = 'raindrop-window-sync-';
-
-async function loadActiveSyncSessionsIntoMemory() {
-  try {
-    const data = await chromeP.storageGet(ACTIVE_SYNC_SESSIONS_KEY);
-    const saved = data && data[ACTIVE_SYNC_SESSIONS_KEY];
-    const obj = saved && typeof saved === 'object' ? saved : {};
-    windowSyncSessions.clear();
-    for (const [k, v] of Object.entries(obj)) {
-      const winId = Number(k);
-      const collectionId = Number(v && v.collectionId);
-      const name = String(v && v.name) || '';
-      if (!Number.isFinite(winId) || !Number.isFinite(collectionId)) continue;
-      windowSyncSessions.set(winId, {
-        collectionId,
-        windowId: winId,
-        name,
-      });
-    }
-  } catch (_) {}
-}
-
-async function persistActiveSyncSessions() {
-  const obj = {};
-  for (const [winId, sess] of windowSyncSessions.entries()) {
-    obj[String(winId)] = { collectionId: sess.collectionId, name: sess.name };
-  }
-  try {
-    await chromeP.storageSet({ [ACTIVE_SYNC_SESSIONS_KEY]: obj });
-  } catch (_) {}
-}
-
-// Initialize from storage on service worker start
-(async () => {
-  await loadActiveSyncSessionsIntoMemory();
-  try {
-    restoreActionUiForActiveWindow();
-  } catch (_) {}
-})();
-
-/**
- * Creates a collection titled with a sync prefix under Saved Projects and seeds it
- * with current window tabs, then starts listening to window/tab/group changes
- * to keep the collection contents overridden with latest tabs.
- * @param {string} projectName
- * @param {number} windowId
- */
-async function startSyncCurrentWindowAsProject(projectName, windowId) {
-  const rawName = String(projectName || '').trim();
-  if (!rawName || !Number.isFinite(Number(windowId))) return;
-  const syncTitle = `⏫ ${rawName}`;
-  setBadge('🔄', '#6366f1'); // indigo-500
-  try {
-    const pn = projectNameWithoutPrefix(syncTitle);
-    setActionTitle(
-      pn
-        ? `Tabs in this window are syncing to ${pn}`
-        : 'This window is syncing to a Saved Project',
-    );
-  } catch (_) {}
-  try {
-    // Ensure Saved Projects group exists and create a new root collection
-    const collectionId = await createCollectionUnderSavedProjects(syncTitle);
-
-    // Initial seed with current window tabs
-    await overrideCollectionWithWindowTabs(collectionId, Number(windowId));
-
-    // Register session in memory
-    windowSyncSessions.set(Number(windowId), {
-      collectionId: Number(collectionId),
-      windowId: Number(windowId),
-      name: syncTitle,
-    });
-    await persistActiveSyncSessions();
-
-    setBadge('✔️', '#22c55e');
-    scheduleClearBadge(2000);
-    try {
-      restoreActionUiForActiveWindow();
-    } catch (_) {}
-    try {
-      notify(`Sync started: ${syncTitle}`);
-    } catch (_) {}
-  } catch (e) {
-    setBadge('😵', '#ef4444');
-    scheduleClearBadge(3000);
-    try {
-      notify(`Failed to start sync: ${e}`);
-    } catch (_) {}
-    try {
-      restoreActionUiForActiveWindow();
-    } catch (_) {}
-  }
-}
-
-/**
- * Starts syncing an existing Saved Project collection with a browser window.
- * Does not create a new collection; instead, it registers a session that
- * will continuously override the project's items from the window's tabs.
- * @param {number} collectionId
- * @param {string} projectName
- * @param {number} windowId
- */
-async function startSyncWindowToExistingProject(
-  collectionId,
-  projectName,
-  windowId,
-) {
-  const colId = Number(collectionId);
-  const winId = Number(windowId);
-  if (!Number.isFinite(colId) || !Number.isFinite(winId)) return;
-  const name = String(projectName || '');
-  try {
-    windowSyncSessions.set(winId, {
-      collectionId: colId,
-      windowId: winId,
-      name,
-    });
-    await persistActiveSyncSessions();
-  } catch (_) {}
-  try {
-    // Schedule an initial sync shortly after restore to capture any immediate changes
-    scheduleWindowSync(winId, 1500);
-  } catch (_) {}
-  try {
-    restoreActionUiForActiveWindow();
-  } catch (_) {}
-  try {
-    notify(`Sync started: ${name || 'Project'}`);
-  } catch (_) {}
-}
-
-/**
- * Ensure Saved Projects group exists and create a collection with the provided title,
- * then put it at the front of that group's collections ordering.
- * @param {string} title
- * @returns {Promise<number>} collection id
- */
-async function createCollectionUnderSavedProjects(title) {
-  const userRes = await apiGET('/user');
-  const groups = Array.isArray(userRes?.user?.groups)
-    ? userRes.user.groups
-    : [];
-  const savedTitle = 'Saved Projects';
-  let groupsArray = groups.slice();
-  let idx = groupsArray.findIndex((g) => (g && g.title) === savedTitle);
-  if (idx === -1) {
-    groupsArray = groupsArray.concat({
-      title: savedTitle,
-      hidden: false,
-      sort: groupsArray.length,
-      collections: [],
-    });
-    try {
-      await apiPUT('/user', { groups: groupsArray });
-    } catch (_) {}
-    try {
-      const uu = await apiGET('/user');
-      groupsArray = Array.isArray(uu?.user?.groups)
-        ? uu.user.groups
-        : groupsArray;
-    } catch (_) {}
-    idx = groupsArray.findIndex((g) => (g && g.title) === savedTitle);
-  }
-
-  // Create collection
-  const created = await apiPOST('/collection', { title });
-  const createdItem = created && (created.item || created.data || created);
-  const collectionId = createdItem && (createdItem._id ?? createdItem.id);
-  if (collectionId == null) throw new Error('Failed to create collection');
-
-  // Put at front
-  try {
-    const newGroups = groupsArray.slice();
-    const entry = {
-      ...(newGroups[idx] || { title: savedTitle, collections: [] }),
-    };
-    const cols = Array.isArray(entry.collections)
-      ? entry.collections.slice()
-      : [];
-    const filtered = cols.filter((cid) => Number(cid) !== Number(collectionId));
-    entry.collections = [Number(collectionId), ...filtered];
-    newGroups[idx] = entry;
-    await apiPUT('/user', { groups: newGroups });
-  } catch (_) {}
-  return Number(collectionId);
-}
-
-/**
- * Build raindrop items array from tabs in a window, preserving order and metadata.
- * @param {number} windowId
- */
-async function buildItemsFromWindowTabs(windowId) {
-  /** @type {chrome.tabs.Tab[]} */
-  const tabsList = await new Promise((resolve) =>
-    chrome.tabs.query({ windowId: Number(windowId) }, (ts) =>
-      resolve(ts || []),
-    ),
-  );
-  /** @type {chrome.tabGroups.TabGroup[]} */
-  const groupsInWindow = await new Promise((resolve) =>
-    chrome.tabGroups?.query({ windowId: Number(windowId) }, (gs) =>
-      resolve(gs || []),
-    ),
-  );
-  const groupMap = new Map();
-  (groupsInWindow || []).forEach((g) => groupMap.set(g.id, g));
-  const eligible = (tabsList || []).filter(
-    (t) =>
-      t.url && (t.url.startsWith('https://') || t.url.startsWith('http://')),
-  );
-  return eligible.map((t, i) => {
-    const baseTitle = t.title || t.url || '';
-    const group = groupMap.get(t.groupId) || null;
-    const meta = {
-      index: i,
-      pinned: t.pinned,
-      tabGroup: group && group.title,
-      tabGroupColor: group && group.color,
-    };
-    return { link: t.url, title: baseTitle, note: JSON.stringify(meta) };
-  });
-}
-
-/**
- * Override all items in a collection with tabs from a window. Deletes existing items
- * and then bulk creates current items. Stops the session if collection is missing.
- * @param {number} collectionId
- * @param {number} windowId
- */
-async function overrideCollectionWithWindowTabs(collectionId, windowId) {
-  // Verify collection exists
-  try {
-    await apiGET(`/collection/${encodeURIComponent(Number(collectionId))}`);
-  } catch (e) {
-    // Stop session on not found
-    stopWindowSync(windowId);
-    throw e;
-  }
-
-  // Build next state from window tabs first. If nothing to save, do not clear
-  // the existing collection so we don't wipe items when the window closes.
-  const itemsToSave = await buildItemsFromWindowTabs(windowId);
-  if (itemsToSave.length === 0) return;
-
-  // Fast clear: move all items in the collection to Trash in one call
-  try {
-    await apiDELETE(`/raindrops/${encodeURIComponent(Number(collectionId))}`);
-  } catch (_) {}
-  try {
-    await apiPOST('/raindrops', {
-      items: itemsToSave.map((it) => ({
-        link: it.link,
-        title: it.title,
-        note: it.note,
-        collection: { $id: Number(collectionId) },
-      })),
-    });
-  } catch (_) {
-    for (const it of itemsToSave) {
-      try {
-        await apiPOST('/raindrop', {
-          link: it.link,
-          title: it.title,
-          note: it.note,
-          collection: { $id: Number(collectionId) },
-        });
-      } catch (_) {}
-    }
-  }
-}
-
-function scheduleWindowSync(windowId, timeoutMs = 1500) {
-  const sess = windowSyncSessions.get(Number(windowId));
-  if (!sess || sess.stopped) return;
-  const name = `${WINDOW_SYNC_ALARM_PREFIX}${Number(windowId)}`;
-  try {
-    chrome.alarms.clear(name, () => {
-      try {
-        chrome.alarms.create(name, {
-          when: Date.now() + Math.max(300, Number(timeoutMs) || 1500),
-        });
-      } catch (_) {}
-    });
-  } catch (_) {}
-}
-
-function stopWindowSync(windowId) {
-  const sess = windowSyncSessions.get(Number(windowId));
-  if (!sess) return;
-  sess.stopped = true;
-  try {
-    chrome.alarms.clear(`${WINDOW_SYNC_ALARM_PREFIX}${Number(windowId)}`);
-  } catch (_) {}
-  windowSyncSessions.delete(Number(windowId));
-  persistActiveSyncSessions();
-}
-
-// Tabs change listeners → schedule sync for that window if active
+// Windows/tabs listeners to drive window sync badge/title and scheduling
 chrome.tabs?.onCreated.addListener((tab) => {
   try {
     const winId = tab && tab.windowId;
     if (!windowSyncSessions.has(Number(winId))) return;
-    scheduleWindowSync(Number(winId));
+    scheduleWindowSync(chrome, Number(winId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 chrome.tabs?.onRemoved.addListener((_tabId, removeInfo) => {
   try {
     const winId = removeInfo && removeInfo.windowId;
     if (!windowSyncSessions.has(Number(winId))) return;
-    scheduleWindowSync(Number(winId));
+    scheduleWindowSync(chrome, Number(winId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 chrome.tabs?.onUpdated.addListener((_tabId, changeInfo, tab) => {
@@ -1969,13 +550,12 @@ chrome.tabs?.onUpdated.addListener((_tabId, changeInfo, tab) => {
       'pinned' in (changeInfo || {}) ||
       (changeInfo && changeInfo.status === 'complete')
     ) {
-      scheduleWindowSync(Number(winId));
+      scheduleWindowSync(chrome, Number(winId));
     }
   } catch (_) {}
-  // Keep action UI in sync as active tab/window changes
   try {
     if (changeInfo && changeInfo.status === 'complete') {
-      restoreActionUiForActiveWindow();
+      restoreActionUiForActiveWindow(chrome, chromeP);
     }
   } catch (_) {}
 });
@@ -1983,129 +563,84 @@ chrome.tabs?.onMoved.addListener((_tabId, moveInfo) => {
   try {
     const winId = moveInfo && moveInfo.windowId;
     if (!windowSyncSessions.has(Number(winId))) return;
-    scheduleWindowSync(Number(winId));
+    scheduleWindowSync(chrome, Number(winId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 chrome.tabs?.onAttached.addListener((_tabId, attachInfo) => {
   try {
     const winId = attachInfo && attachInfo.newWindowId;
     if (!windowSyncSessions.has(Number(winId))) return;
-    scheduleWindowSync(Number(winId));
+    scheduleWindowSync(chrome, Number(winId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 chrome.tabs?.onDetached.addListener((_tabId, detachInfo) => {
   try {
     const winId = detachInfo && detachInfo.oldWindowId;
     if (!windowSyncSessions.has(Number(winId))) return;
-    scheduleWindowSync(Number(winId));
+    scheduleWindowSync(chrome, Number(winId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
-
-// Window focus/creation → ensure badge/title reflect the focused window's sync state
 chrome.windows?.onFocusChanged?.addListener((_windowId) => {
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 chrome.windows?.onCreated?.addListener((_window) => {
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 chrome.tabs?.onActivated?.addListener((_activeInfo) => {
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
-
-// Tab group changes
 chrome.tabGroups?.onCreated?.addListener((_group) => {
   try {
     for (const winId of windowSyncSessions.keys())
-      scheduleWindowSync(Number(winId));
+      scheduleWindowSync(chrome, Number(winId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 chrome.tabGroups?.onUpdated?.addListener((_group) => {
   try {
     for (const winId of windowSyncSessions.keys())
-      scheduleWindowSync(Number(winId));
+      scheduleWindowSync(chrome, Number(winId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 chrome.tabGroups?.onRemoved?.addListener((_group) => {
   try {
     for (const winId of windowSyncSessions.keys())
-      scheduleWindowSync(Number(winId));
+      scheduleWindowSync(chrome, Number(winId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
-
-// Stop syncing when window is closed
 chrome.windows?.onRemoved.addListener((windowId) => {
   try {
-    stopWindowSync(Number(windowId));
+    stopWindowSync(chrome, Number(windowId));
   } catch (_) {}
   try {
-    restoreActionUiForActiveWindow();
-  } catch (_) {}
-});
-chrome.runtime.onStartup?.addListener(() => {
-  try {
-    chrome.alarms.create(ALARM_NAME, { periodInMinutes: SYNC_PERIOD_MINUTES });
-  } catch (_) {}
-  // Popup handles interactions; nothing to update here
-  try {
-    restoreActionUiForActiveWindow();
+    restoreActionUiForActiveWindow(chrome, chromeP);
   } catch (_) {}
 });
 
-chrome.alarms.onAlarm.addListener((alarm) => {
-  if (alarm && alarm.name === ALARM_NAME) {
-    // Note: async function keeps service worker alive until completion
-    performSync();
-  } else if (alarm && alarm.name === 'raindrop-clear-badge') {
-    clearBadge();
-  } else if (
-    alarm &&
-    alarm.name &&
-    alarm.name.startsWith('raindrop-window-sync-')
-  ) {
-    const suffix = alarm.name.substring('raindrop-window-sync-'.length);
-    const winId = Number(suffix);
-    const sess = windowSyncSessions.get(Number(winId));
-    if (!sess || sess.stopped) return;
-    (async () => {
-      try {
-        await overrideCollectionWithWindowTabs(
-          sess.collectionId,
-          sess.windowId,
-        );
-      } catch (_) {}
-    })();
-  }
-  // After any alarm, ensure persistent UI is restored if needed
-  try {
-    restoreActionUiForActiveWindow();
-  } catch (_) {}
-});
-
-// Popup commands → message listener
+// Message router for popup commands
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   (async () => {
     try {
@@ -2121,17 +656,14 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       }
       if (message && message.type === 'recoverSavedProject') {
         const id = message && message.id;
-        const restoreResult = await recoverSavedProject(id);
-        // If we just focused an existing synced window, stop here and do not notify
+        const restoreResult = await recoverSavedProject(chrome, id);
         if (restoreResult && restoreResult.focusedExisting) {
           sendResponse({ ok: true });
           return;
         }
-        // If the recovered project's title starts with the sync emoji, begin a live sync
         try {
           const colId = Number(id);
           if (Number.isFinite(colId)) {
-            // Fetch title to check prefix and to pass exact name
             const res = await apiGET(
               `/collection/${encodeURIComponent(colId)}`,
             );
@@ -2139,7 +671,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
             const title = String(item.title || '');
             const shouldSync = /^\s*⏫?\s+/.test(title);
             if (shouldSync) {
-              // Resolve a new normal window (the one we just created)
               let winId = null;
               try {
                 const normals = await new Promise((resolve) =>
@@ -2148,7 +679,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                   ),
                 );
                 if (Array.isArray(normals) && normals.length) {
-                  // Assume the last focused is the newly created one
                   const lastFocused =
                     normals.find((w) => w.focused) || normals[0];
                   winId = lastFocused && lastFocused.id;
@@ -2156,6 +686,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
               } catch (_) {}
               if (Number.isFinite(Number(winId))) {
                 await startSyncWindowToExistingProject(
+                  chromeP,
                   colId,
                   title,
                   Number(winId),
@@ -2167,10 +698,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         sendResponse({ ok: true });
         return;
       }
-      // removed: replaceSavedProject, replaceSavedProjectWithCurrentWindowTabs
       if (message && message.type === 'deleteSavedProject') {
         const id = message && message.id;
-        await deleteSavedProject(id);
+        await deleteSavedProject(chromeP, id);
         sendResponse({ ok: true });
         return;
       }
@@ -2178,20 +708,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         message &&
         message.type === 'saveCurrentOrHighlightedTabsToRaindrop'
       ) {
-        await saveCurrentOrHighlightedTabsToRaindrop();
+        await saveCurrentOrHighlightedTabsToRaindrop(chrome, chromeP);
         sendResponse({ ok: true });
         return;
       }
       if (message && message.type === 'saveHighlightedTabsAsProject') {
         const projectName = (message && message.name) || '';
-        await saveHighlightedTabsAsProject(projectName);
+        await saveHighlightedTabsAsProject(chrome, projectName);
         sendResponse({ ok: true });
         return;
       }
-      // removed: saveCurrentWindowAsProject
       if (message && message.type === 'startSyncCurrentWindowAsProject') {
         const projectName = (message && message.name) || '';
-        // Resolve the real browser window id reliably (avoid the popup window id)
         let winId = null;
         try {
           const tabs = await new Promise((resolve) =>
@@ -2213,17 +741,20 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
                 resolve(ws || []),
               ),
             );
-            if (Array.isArray(normals) && normals.length) {
-              // pick the first normal window; better than none
+            if (Array.isArray(normals) && normals.length)
               winId = Number(normals[0].id);
-            }
           } catch (_) {}
         }
         if (!Number.isFinite(winId)) {
           sendResponse({ ok: false, error: 'NO_WINDOW_ID' });
           return;
         }
-        await startSyncCurrentWindowAsProject(projectName, Number(winId));
+        await startSyncCurrentWindowAsProject(
+          chrome,
+          chromeP,
+          projectName,
+          Number(winId),
+        );
         sendResponse({ ok: true });
         return;
       }
@@ -2231,759 +762,22 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       sendResponse({ ok: false });
     }
   })();
-  return true; // keep the message channel open for async sendResponse
+  return true;
 });
 
-/**
- * Saves the current active tab or highlighted tabs to Raindrop Unsorted collection
- * and creates local bookmarks at the top of the local Unsorted folder.
- */
-async function saveCurrentOrHighlightedTabsToRaindrop() {
-  // Show badge
-  setBadge('⬆️', '#f59e0b'); // amber-500
-  let titlesAndUrls = [];
-  try {
-    const tabs = await new Promise((resolve) =>
-      chrome.tabs.query(
-        { windowId: chrome.windows.WINDOW_ID_CURRENT, highlighted: true },
-        (ts) => resolve(ts || []),
-      ),
-    );
-    let candidates =
-      Array.isArray(tabs) && tabs.length > 0
-        ? tabs
-        : await new Promise((resolve) =>
-            chrome.tabs.query({ active: true, currentWindow: true }, (ts) =>
-              resolve(ts || []),
-            ),
-          );
-    for (const t of candidates) {
-      const url = (t && t.url) || '';
-      if (url && (url.startsWith('https://') || url.startsWith('http://'))) {
-        titlesAndUrls.push({ title: (t && t.title) || url, url });
-      }
-    }
-    if (titlesAndUrls.length === 0)
-      throw new Error('No eligible tabs to save.');
-
-    // Ensure we have collection mapping and local Unsorted folder id
-    const state = await loadState();
-    const collectionMap = { ...(state.collectionMap || {}) };
-    const unsortedFolderId = await ensureUnsortedFolder(collectionMap);
-
-    // POST many to Raindrop unsorted with pleaseParse
-    await loadTokenIfNeeded();
-    const body = {
-      items: titlesAndUrls.map(({ title, url }) => ({
-        link: url,
-        title: title || url,
-        collection: { $id: UNSORTED_COLLECTION_ID },
-        pleaseParse: {},
-      })),
-    };
-    const res = await raindropPOST('raindrops', body);
-    const createdItems = res && Array.isArray(res.items) ? res.items : [];
-    const successCount = createdItems.length;
-
-    // Create local bookmarks at top of Unsorted for the source URLs (avoid empty folders)
-    // Map Raindrop ids by link so we can persist itemMap
-    const linkToId = new Map();
-    for (const it of createdItems) {
-      const link = it && (it.link || it.url);
-      const id =
-        it &&
-        (it._id != null ? String(it._id) : it.id != null ? String(it.id) : '');
-      if (link && id) linkToId.set(link, id);
-    }
-    const toCreateLocally = titlesAndUrls.map(({ title, url }) => ({
-      id: linkToId.get(url) || '',
-      title: title || url,
-      url,
-    }));
-    // Prevent duplicate mirror creation: mark these URLs as already saved remotely
-    rememberRecentlyCreatedRemoteUrls(toCreateLocally.map(({ url }) => url));
-    // Merge mappings so future sync recognizes these new items
-    const mergedItemMap = { ...((state && state.itemMap) || {}) };
-    suppressLocalBookmarkEvents = true;
-    try {
-      for (const { id, title, url } of toCreateLocally.slice().reverse()) {
-        try {
-          const node = await chromeP.bookmarksCreate({
-            parentId: unsortedFolderId,
-            title: title || url,
-            url,
-            index: 0,
-          });
-          if (id) mergedItemMap[id] = node.id;
-        } catch (_) {}
-      }
-    } finally {
-      suppressLocalBookmarkEvents = false;
-    }
-    try {
-      await saveState({ itemMap: mergedItemMap });
-    } catch (_) {}
-
-    if (successCount > 0) {
-      setBadge('✔️', '#22c55e'); // green-500
-      scheduleClearBadge(3000);
-      try {
-        notify(
-          `Saved ${successCount} page${
-            successCount > 1 ? 's' : ''
-          } to Raindrop`,
-        );
-      } catch (_) {}
-    } else {
-      setBadge('😵', '#ef4444');
-      scheduleClearBadge(3000);
-      try {
-        notify('Failed to save tab(s) to Raindrop');
-      } catch (_) {}
-    }
-  } catch (err) {
-    setBadge('😵', '#ef4444');
-    scheduleClearBadge(3000);
-    try {
-      notify('Failed to save tab(s) to Raindrop');
-    } catch (_) {}
-    try {
-      restoreActionUiForActiveWindow();
-    } catch (_) {}
-  }
-}
-
-/**
- * Save highlighted tabs, or entire current window when none highlighted,
- * into Raindrop under a group named "Saved Projects" as a new root collection
- * using the provided projectName.
- *
- * Each tab is saved with formatted title:
- * - If in a tab group: "[<groupIndex>] <groupTitle> / <indexInGroup> <tabTitle>"
- * - Else: "<indexInWindow> <tabTitle>"
- *
- * @param {string} projectName
- */
-async function saveHighlightedTabsAsProject(projectName) {
-  const name = String(projectName || '').trim();
-  if (!name) return;
-
-  // Gather highlighted; if none later, fallback handled in helper
-  let /** @type {chrome.tabs.Tab[]} */ tabsList = await new Promise((resolve) =>
-      chrome.tabs.query(
-        { windowId: chrome.windows.WINDOW_ID_CURRENT, highlighted: true },
-        (ts) => resolve(ts || []),
-      ),
-    );
-  await saveTabsListAsProject(name, tabsList || []);
-}
-
-/**
- * Internal helper to persist a list of tabs into a new project collection under
- * the "Saved Projects" group. Handles grouping, collection creation and bulk save.
- * @param {string} name
- * @param {chrome.tabs.Tab[]} tabsList
- */
-async function saveTabsListAsProject(name, tabsList) {
-  setBadge('💾', '#a855f7');
-  try {
-    // Filter http(s)
-    const eligibleTabs = (tabsList || []).filter(
-      (t) =>
-        t.url && (t.url.startsWith('https://') || t.url.startsWith('http://')),
-    );
-    if (!eligibleTabs.length) throw new Error('No eligible tabs');
-
-    // Compute formatted titles with tab group context
-    const /** @type {chrome.tabGroups.TabGroup[]} */ groupsInWindow =
-        await new Promise((resolve) =>
-          chrome.tabGroups?.query(
-            { windowId: chrome.windows.WINDOW_ID_CURRENT },
-            (gs) => resolve(gs || []),
-          ),
-        );
-    const /** @type {Map<number, chrome.tabGroups.TabGroup>} */ groupIdToMeta =
-        new Map();
-    (groupsInWindow || []).slice().forEach((g) => {
-      groupIdToMeta.set(g.id, g);
-    });
-
-    const items = eligibleTabs.map((t, i) => {
-      const baseTitle = t.title || t.url || '';
-      const group = groupIdToMeta.get(t.groupId) || null;
-      const meta = {
-        index: i,
-        pinned: t.pinned,
-        tabGroup: group && group.title,
-        tabGroupColor: group && group.color,
-      };
-      return {
-        link: t.url,
-        title: baseTitle,
-        note: JSON.stringify(meta),
-      };
-    });
-
-    // Ensure "Saved Projects" group exists and create project root collection under it
-    const userRes = await apiGET('/user');
-    const groups =
-      userRes && userRes.user && Array.isArray(userRes.user.groups)
-        ? userRes.user.groups
-        : [];
-    const savedProjectsTitle = 'Saved Projects';
-    let groupsArray = groups.slice();
-    let groupIndex = groupsArray.findIndex(
-      (g) => (g.title || '') === savedProjectsTitle,
-    );
-    if (groupIndex === -1) {
-      groupsArray = groupsArray.concat({
-        title: savedProjectsTitle,
-        hidden: false,
-        sort: groupsArray.length,
-        collections: [],
-      });
-      try {
-        await apiPUT('/user', { groups: groupsArray });
-      } catch (_) {}
-      // refetch just to be safe
-      try {
-        const uu = await apiGET('/user');
-        groupsArray =
-          uu && uu.user && Array.isArray(uu.user.groups)
-            ? uu.user.groups
-            : groupsArray;
-      } catch (_) {}
-      groupIndex = groupsArray.findIndex(
-        (g) => (g.title || '') === savedProjectsTitle,
-      );
-    }
-
-    // Create root collection for project
-    const created = await apiPOST('/collection', { title: name });
-    const createdItem = created && (created.item || created.data || created);
-    const projectCollectionId =
-      createdItem && (createdItem._id ?? createdItem.id);
-    if (projectCollectionId == null)
-      throw new Error('Failed to create collection');
-
-    // Add to Saved Projects group list in correct position (prepend to first)
-    try {
-      const newGroups = groupsArray.slice();
-      const entry = {
-        ...(newGroups[groupIndex] || {
-          title: savedProjectsTitle,
-          collections: [],
-        }),
-      };
-      const cols = Array.isArray(entry.collections)
-        ? entry.collections.slice()
-        : [];
-      // Ensure new project collection id is first, without duplication
-      const filtered = cols.filter((cid) => cid !== projectCollectionId);
-      entry.collections = [projectCollectionId, ...filtered];
-      newGroups[groupIndex] = entry;
-      await apiPUT('/user', { groups: newGroups });
-    } catch (_) {}
-
-    // Bulk save items into that collection
-    const body = {
-      items: items.map((it) => ({
-        link: it.link,
-        title: it.title,
-        note: it.note,
-        collection: { $id: Number(projectCollectionId) },
-      })),
-    };
-    try {
-      await apiPOST('/raindrops', body);
-    } catch (_) {
-      // fallback individual if bulk fails
-      for (const it of items) {
-        try {
-          await apiPOST('/raindrop', {
-            link: it.link,
-            title: it.title,
-            note: it.note,
-            collection: { $id: Number(projectCollectionId) },
-          });
-        } catch (_) {}
-      }
-    }
-
-    setBadge('✔️', '#22c55e');
-    scheduleClearBadge(3000);
-    try {
-      notify(
-        `Saved ${items.length} tab${
-          items.length > 1 ? 's' : ''
-        } to ${savedProjectsTitle}/${name}`,
-      );
-    } catch (_) {}
-  } catch (e) {
-    setBadge('😵', '#ef4444');
-    scheduleClearBadge(3000);
-    try {
-      notify(`Failed to save project: ${e}`);
-    } catch (_) {}
-    try {
-      restoreActionUiForActiveWindow();
-    } catch (_) {}
-  }
-}
-
-/**
- * Lists root collections that belong to the "Saved Projects" group, in the
- * exact order specified by the group's `collections` array.
- * @returns {Promise<Array<{id:number,title:string,count?:number,lastUpdate?:string,cover?:string}>>}
- */
-async function listSavedProjects() {
-  // Fetch groups and root collections
-  const [userRes, rootsRes] = await Promise.all([
-    apiGET('/user'),
-    apiGET('/collections'),
-  ]);
-  const groups =
-    userRes && userRes.user && Array.isArray(userRes.user.groups)
-      ? userRes.user.groups
-      : [];
-  const saved = groups.find((g) => (g && g.title) === 'Saved Projects');
-  const order =
-    saved && Array.isArray(saved.collections) ? saved.collections : [];
-  const rootCollections = Array.isArray(rootsRes?.items) ? rootsRes.items : [];
-  const byId = new Map();
-  for (const c of rootCollections) {
-    if (c && c._id != null) byId.set(c._id, c);
-  }
-  const result = [];
-  for (const id of order) {
-    const c = byId.get(id);
-    if (!c) continue;
-    result.push({
-      id: c._id,
-      title: c.title || '',
-      count: c.count,
-      lastUpdate: c.lastUpdate,
-      cover: Array.isArray(c.cover) ? c.cover[0] || '' : c.cover || '',
-    });
-  }
-  return result;
-}
-
-/**
- * Recover a saved project by collection id: opens a new window, recreates tabs
- * in the saved order, and restores tab groups (title and color) when metadata
- * is present. Handles missing/invalid metadata and sparse indices.
- * @param {number|string} collectionId
- */
-async function recoverSavedProject(collectionId) {
-  const colId = Number(collectionId);
-  if (!Number.isFinite(colId)) return;
-
-  // If this project is already syncing with an existing window, focus that window
-  // instead of creating a new one.
-  try {
-    let existingWinId = null;
-    for (const sess of windowSyncSessions.values()) {
-      if (sess && !sess.stopped && Number(sess.collectionId) === colId) {
-        existingWinId = sess.windowId;
-        break;
-      }
-    }
-    if (Number.isFinite(Number(existingWinId))) {
-      // Verify the window still exists
-      let existingWindow = null;
-      try {
-        existingWindow = await new Promise((resolve) =>
-          chrome.windows.get(Number(existingWinId), (w) => resolve(w)),
-        );
-      } catch (_) {}
-      if (existingWindow) {
-        try {
-          await chrome.windows.update(Number(existingWinId), { focused: true });
-        } catch (_) {}
-        return { focusedExisting: true, windowId: Number(existingWinId) };
-      } else {
-        // Clean up stale session mapping and proceed to restore
-        try {
-          windowSyncSessions.delete(Number(existingWinId));
-          await persistActiveSyncSessions();
-        } catch (_) {}
-      }
-    }
-  } catch (_) {}
-
-  // Export all items on that collection
-  const html = await apiGETText(`/raindrops/${colId}/export.html`);
-
-  /**
-   * @typedef {Object} SavedProjectBasicMeta
-   * @property {number} index
-   * @property {boolean} [pinned]
-   */
-
-  /**
-   * @typedef {Object} SavedProjectTabGroupMeta
-   * @property {string} [tabGroup]
-   * @property {string} [tabGroupColor]
-   */
-
-  /**
-   * @typedef {SavedProjectBasicMeta & SavedProjectTabGroupMeta} SavedProjectItemMeta
-   */
-
-  /**
-   * @typedef {Object} SavedProjectItem
-   * @property {string} url
-   * @property {string} title
-   * @property {SavedProjectItemMeta} [meta]
-   */
-
-  // Parse Netscape bookmark HTML. Extract url, title, and metadata JSON from DD after each A.
-  try {
-    const /** @type {SavedProjectItem[]} */ items = [];
-
-    // Regex to find A tags inside DL sections; capture href and inner text.
-    const linkRegex = /<DT>\s*<A\s+[^>]*HREF="([^"]+)"[^>]*>([\s\S]*?)<\/A>/gi;
-    const ddRegex = /<DD>\s*([\s\S]*?)(?=(?:<DT>|<\/DL>|$))/i;
-    let match;
-    while ((match = linkRegex.exec(html)) !== null) {
-      const url = match[1] ? match[1].trim() : '';
-      const rawTitle = match[2] || '';
-      const title = rawTitle
-        .replace(/\s+/g, ' ')
-        .replace(/<[^>]*>/g, '')
-        .trim();
-      // Look ahead from the end of this A tag for a following <DD> block
-      const tail = html.slice(linkRegex.lastIndex);
-      const ddMatch = ddRegex.exec(tail);
-      let meta;
-      if (ddMatch && ddMatch[1]) {
-        const ddText = ddMatch[1]
-          .replace(/\n|\r/g, ' ')
-          .replace(/\s+/g, ' ')
-          .trim();
-        // HTML entities for quotes in sample are &quot;
-        const normalized = ddText
-          .replace(/&quot;/g, '"')
-          .replace(/&#39;/g, "'");
-        try {
-          meta = JSON.parse(normalized);
-        } catch (_) {
-          meta = undefined;
-        }
-      }
-      items.push({ url, title, meta });
-    }
-
-    if (items.length === 0) {
-      throw new Error('No items found in export.html');
-    }
-
-    const sorted = items.sort(
-      (a, b) => (a.meta?.index ?? 0) - (b.meta?.index ?? 0),
-    );
-
-    // Create a new window with the first URL to avoid an NTP/blank tab
-    const first = sorted[0];
-    const newWindow = await chrome.windows.create({
-      focused: true,
-      url: first.url,
-    });
-    if (!newWindow) {
-      throw new Error('Failed to create new window');
-    }
-
-    // Ensure the first tab's pin state matches metadata
-    const [activeTab] = await chrome.tabs.query({
-      windowId: newWindow.id,
-      active: true,
-    });
-    if (activeTab && activeTab.id && (first.meta?.pinned ?? false)) {
-      try {
-        await chrome.tabs.update(activeTab.id, { pinned: true });
-      } catch (_) {}
-    }
-
-    /**
-     * @typedef {Object} TabGroupInfo
-     * @property {SavedProjectTabGroupMeta} meta
-     * @property {number[]} tabIds
-     */
-
-    const /** @type {TabGroupInfo[]} */ tabGroups = [];
-
-    // If the first tab belongs to a group, seed it
-    if (activeTab && activeTab.id && first.meta?.tabGroup) {
-      tabGroups.push({
-        meta: {
-          tabGroup: first.meta?.tabGroup,
-          tabGroupColor: first.meta?.tabGroupColor,
-        },
-        tabIds: [activeTab.id],
-      });
-    }
-
-    // Create remaining tabs
-    for (const it of sorted.slice(1)) {
-      const newTab = await chrome.tabs.create({
-        url: it.url,
-        windowId: newWindow.id,
-        pinned: it.meta?.pinned ?? false,
-      });
-
-      if (newTab && newTab.id && it.meta?.tabGroup !== null) {
-        let group = tabGroups.find(
-          (g) => g.meta.tabGroup === it.meta?.tabGroup,
-        );
-        if (!group) {
-          group = {
-            meta: {
-              tabGroup: it.meta?.tabGroup,
-              tabGroupColor: it.meta?.tabGroupColor,
-            },
-            tabIds: [],
-          };
-          tabGroups.push(group);
-        }
-        group.tabIds.push(newTab.id);
-      }
-    }
-
-    // Create tab groups
-    for (const group of tabGroups) {
-      if (group.tabIds.length > 0) {
-        // @ts-ignore
-        const tg = await chrome.tabs.group({ tabIds: group.tabIds });
-        if (tg) {
-          chrome.tabGroups.update(tg, {
-            title: group.meta.tabGroup,
-            // @ts-ignore
-            color: group.meta.tabGroupColor,
-          });
-        }
-      }
-    }
-
-    // No default tabs to remove because we created the window with a URL
-  } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error('Failed to parse export.html', e);
-  }
-}
-
-/**
- * Core logic to replace a Saved Project collection with a provided list of tabs.
- * Creates a new collection preserving title and cover, reorders Saved Projects,
- * saves tab items with metadata, and deletes the old collection.
- * @param {number|string} collectionId
- * @param {chrome.tabs.Tab[]} tabsList
- * @returns {Promise<{ title: string, count: number }>}
- */
-async function replaceSavedProjectWithTabs(collectionId, tabsList) {
-  const oldId = Number(collectionId);
-  if (!Number.isFinite(oldId)) return { title: 'Project', count: 0 };
-
-  // Filter http(s) and build items with metadata (group title/color, pinned, index)
-  const eligibleTabs = (tabsList || []).filter(
-    (t) =>
-      t.url && (t.url.startsWith('https://') || t.url.startsWith('http://')),
-  );
-  if (eligibleTabs.length === 0) throw new Error('No eligible http(s) tabs');
-
-  /** @type {chrome.tabGroups.TabGroup[]} */
-  const groupsInWindow = await new Promise((resolve) =>
-    chrome.tabGroups?.query(
-      { windowId: chrome.windows.WINDOW_ID_CURRENT },
-      (gs) => resolve(gs || []),
-    ),
-  );
-  const groupIdToMeta = new Map();
-  (groupsInWindow || []).forEach((g) => groupIdToMeta.set(g.id, g));
-  const items = eligibleTabs.map((t, i) => {
-    const baseTitle = t.title || t.url || '';
-    const group = groupIdToMeta.get(t.groupId) || null;
-    const meta = {
-      index: i,
-      pinned: t.pinned,
-      tabGroup: group && group.title,
-      tabGroupColor: group && group.color,
-    };
-    return { link: t.url, title: baseTitle, note: JSON.stringify(meta) };
-  });
-
-  // Look up the existing collection title/cover and Saved Projects group ordering
-  const [userRes, rootsRes] = await Promise.all([
-    apiGET('/user'),
-    apiGET('/collections'),
-  ]);
-  const groups = Array.isArray(userRes?.user?.groups)
-    ? userRes.user.groups
-    : [];
-  const savedIdx = groups.findIndex((g) => (g && g.title) === 'Saved Projects');
-  const savedGroup = savedIdx >= 0 ? groups[savedIdx] : null;
-  const order = Array.isArray(savedGroup?.collections)
-    ? savedGroup.collections.slice()
-    : [];
-  const pos = order.findIndex((cid) => Number(cid) === oldId);
-
-  const roots = Array.isArray(rootsRes?.items) ? rootsRes.items : [];
-  const existing = roots.find((c) => Number(c?._id) === oldId);
-  const title = existing?.title || 'Project';
-  const existingCoverArray = Array.isArray(existing?.cover)
-    ? existing.cover.filter(Boolean)
-    : existing?.cover
-    ? [existing.cover]
-    : [];
-
-  // Create a new collection with the same title
-  const created = await apiPOST('/collection', { title });
-  const createdItem = created && (created.item || created.data || created);
-  const newId = createdItem && (createdItem._id ?? createdItem.id);
-  if (newId == null) throw new Error('Failed to create collection');
-
-  // Preserve existing cover if there was one
-  if (existingCoverArray.length > 0) {
-    try {
-      await apiPUT(`/collection/${encodeURIComponent(newId)}`, {
-        cover: existingCoverArray,
-      });
-    } catch (_) {}
-  }
-
-  // Update Saved Projects group ordering: replace oldId with newId at the same index
-  try {
-    if (savedIdx >= 0) {
-      const newGroups = groups.slice();
-      const entry = {
-        ...(newGroups[savedIdx] || {
-          title: 'Saved Projects',
-          collections: [],
-        }),
-      };
-      const cols = Array.isArray(entry.collections)
-        ? entry.collections.slice()
-        : [];
-      if (pos >= 0) {
-        cols.splice(pos, 1, Number(newId));
-      } else {
-        const filtered = cols.filter((cid) => Number(cid) !== Number(newId));
-        filtered.unshift(Number(newId));
-        entry.collections = filtered;
-      }
-      if (pos >= 0) entry.collections = cols;
-      newGroups[savedIdx] = entry;
-      await apiPUT('/user', { groups: newGroups });
-    }
-  } catch (_) {}
-
-  // Bulk save items into new collection
-  try {
-    await apiPOST('/raindrops', {
-      items: items.map((it) => ({
-        link: it.link,
-        title: it.title,
-        note: it.note,
-        collection: { $id: Number(newId) },
-      })),
-    });
-  } catch (_) {
-    for (const it of items) {
-      try {
-        await apiPOST('/raindrop', {
-          link: it.link,
-          title: it.title,
-          note: it.note,
-          collection: { $id: Number(newId) },
-        });
-      } catch (_) {}
-    }
-  }
-
-  // Remove old collection
-  try {
-    await apiDELETE(`/collection/${encodeURIComponent(oldId)}`);
-  } catch (_) {}
-
-  return { title, count: items.length };
-}
-
-/**
- * Delete a Saved Project: remove collection and update Saved Projects group ordering.
- * @param {number|string} collectionId
- */
-async function deleteSavedProject(collectionId) {
-  const colId = Number(collectionId);
-  if (!Number.isFinite(colId)) return;
-
-  setBadge('🗑️', '#ef4444');
-  try {
-    // Fetch title and groups
-    const [userRes, rootsRes] = await Promise.all([
-      apiGET('/user'),
-      apiGET('/collections'),
-    ]);
-    const groups = Array.isArray(userRes?.user?.groups)
-      ? userRes.user.groups
-      : [];
-    const idx = groups.findIndex((g) => (g && g.title) === 'Saved Projects');
-    if (idx >= 0) {
-      const newGroups = groups.slice();
-      const entry = {
-        ...(newGroups[idx] || { title: 'Saved Projects', collections: [] }),
-      };
-      const cols = Array.isArray(entry.collections)
-        ? entry.collections.slice()
-        : [];
-      entry.collections = cols.filter((cid) => Number(cid) !== colId);
-      newGroups[idx] = entry;
-      try {
-        await apiPUT('/user', { groups: newGroups });
-      } catch (_) {}
-    }
-
-    const roots = Array.isArray(rootsRes?.items) ? rootsRes.items : [];
-    const existing = roots.find((c) => Number(c?._id) === colId);
-    const title = existing?.title || 'Project';
-
-    // Delete collection
-    try {
-      await apiDELETE(`/collection/${encodeURIComponent(colId)}`);
-    } catch (_) {}
-
-    setBadge('✔️', '#22c55e');
-    scheduleClearBadge(3000);
-    try {
-      notify(`Deleted project "${title}"`);
-    } catch (_) {}
-  } catch (e) {
-    setBadge('😵', '#ef4444');
-    scheduleClearBadge(3000);
-    try {
-      notify(`Failed to delete project: ${e}`);
-    } catch (_) {}
-    try {
-      restoreActionUiForActiveWindow();
-    } catch (_) {}
-  }
-}
-
-// Listen for storage changes to update token immediately
 chrome.storage?.onChanged.addListener((changes, area) => {
   if (area === 'local' && changes && changes.raindropApiToken) {
     const newToken = (changes.raindropApiToken.newValue || '').trim();
     const oldToken = (changes.raindropApiToken.oldValue || '').trim();
-    RAINDROP_API_TOKEN = newToken;
+    setFacadeToken(newToken);
     if (newToken && newToken !== oldToken) {
-      // Token provided/updated → attempt immediate sync
       try {
         performSync();
       } catch (_) {}
     }
   }
-  // Action button preferences removed; no-op
 });
 
-// Open Options when user clicks token notification
 chrome.notifications?.onClicked.addListener((notificationId) => {
   if (notificationId === TOKEN_NOTIFICATION_ID) {
     try {

--- a/src/background.js
+++ b/src/background.js
@@ -142,7 +142,9 @@ async function performSync() {
       getOrCreateChildFolderLocal,
     );
     const { itemMap: prunedItemMap, didChange: deletionsChanged } =
-      await syncDeletedItems(state.lastSync, updatedItemMap, collectionMap);
+      state.lastSync
+        ? await syncDeletedItems(state.lastSync, updatedItemMap, collectionMap)
+        : { itemMap: updatedItemMap, didChange: false };
     hasAnyChanges = Boolean(foldersChanged || itemsChanged || deletionsChanged);
     await saveState({
       lastSync: newLastSyncISO,

--- a/src/modules/api-facade.js
+++ b/src/modules/api-facade.js
@@ -1,0 +1,108 @@
+// High-level Raindrop API facade that wraps low-level API calls with
+// token loading and user notifications for missing/invalid tokens.
+import {
+  apiGET as lowGET,
+  apiPOST as lowPOST,
+  apiPUT as lowPUT,
+  apiDELETE as lowDELETE,
+  apiGETText as lowGETText,
+  setApiToken as setLowToken,
+  loadTokenIfNeeded,
+} from './raindrop.js';
+import { notifyMissingOrInvalidToken } from './notifications.js';
+import { chromeP } from './chrome.js';
+
+let RAINDROP_API_TOKEN = '';
+
+async function ensureToken() {
+  if (!RAINDROP_API_TOKEN) {
+    try {
+      const data = await chromeP.storageGet('raindropApiToken');
+      RAINDROP_API_TOKEN =
+        data && data.raindropApiToken ? data.raindropApiToken : '';
+    } catch (_) {}
+  }
+  if (!RAINDROP_API_TOKEN) {
+    notifyMissingOrInvalidToken(
+      'No API token configured. Please add your Raindrop API token.',
+    );
+    throw new Error('Missing Raindrop API token');
+  }
+  setLowToken(RAINDROP_API_TOKEN);
+  await loadTokenIfNeeded();
+}
+
+export function setFacadeToken(token) {
+  RAINDROP_API_TOKEN = token || '';
+  setLowToken(RAINDROP_API_TOKEN);
+}
+
+export async function apiGET(pathWithQuery) {
+  try {
+    await ensureToken();
+    return await lowGET(pathWithQuery);
+  } catch (err) {
+    if (err && (err.status === 401 || err.status === 403)) {
+      notifyMissingOrInvalidToken(
+        'Invalid API token. Please update your Raindrop API token.',
+      );
+    }
+    throw err;
+  }
+}
+
+export async function apiGETText(pathWithQuery) {
+  try {
+    await ensureToken();
+    return await lowGETText(pathWithQuery);
+  } catch (err) {
+    if (err && (err.status === 401 || err.status === 403)) {
+      notifyMissingOrInvalidToken(
+        'Invalid API token. Please update your Raindrop API token.',
+      );
+    }
+    throw err;
+  }
+}
+
+export async function apiPOST(path, body) {
+  try {
+    await ensureToken();
+    return await lowPOST(path, body);
+  } catch (err) {
+    if (err && (err.status === 401 || err.status === 403)) {
+      notifyMissingOrInvalidToken(
+        'Invalid API token. Please update your Raindrop API token.',
+      );
+    }
+    throw err;
+  }
+}
+
+export async function apiPUT(path, body) {
+  try {
+    await ensureToken();
+    return await lowPUT(path, body);
+  } catch (err) {
+    if (err && (err.status === 401 || err.status === 403)) {
+      notifyMissingOrInvalidToken(
+        'Invalid API token. Please update your Raindrop API token.',
+      );
+    }
+    throw err;
+  }
+}
+
+export async function apiDELETE(path) {
+  try {
+    await ensureToken();
+    return await lowDELETE(path);
+  } catch (err) {
+    if (err && (err.status === 401 || err.status === 403)) {
+      notifyMissingOrInvalidToken(
+        'Invalid API token. Please update your Raindrop API token.',
+      );
+    }
+    throw err;
+  }
+}

--- a/src/modules/collections.js
+++ b/src/modules/collections.js
@@ -1,0 +1,94 @@
+// Groups and collections fetching and indexing utilities
+import { apiGET } from './api-facade.js';
+
+/**
+ * @typedef {{ title: string, sort?: number, collections?: number[] }} RaindropGroup
+ */
+
+/**
+ * @typedef {{ _id: number, title?: string, parent?: { $id?: number }|number, sort?: number }} RaindropCollection
+ */
+
+export async function fetchGroupsAndCollections() {
+  const [userRes, rootsRes, childrenRes] = await Promise.all([
+    apiGET('/user'),
+    apiGET('/collections'),
+    apiGET('/collections/childrens'),
+  ]);
+  const groups = Array.isArray(userRes?.user?.groups)
+    ? userRes.user.groups
+    : [];
+  const rootCollections =
+    rootsRes && (rootsRes.items || rootsRes.result) ? rootsRes.items || [] : [];
+  const childCollections =
+    childrenRes && (childrenRes.items || childrenRes.result)
+      ? childrenRes.items || []
+      : [];
+  return { groups, rootCollections, childCollections };
+}
+
+export function buildCollectionsIndex(rootCollections, childCollections) {
+  const byId = new Map();
+  for (const c of rootCollections || []) {
+    if (!c || c._id == null) continue;
+    byId.set(c._id, {
+      id: c._id,
+      title: c.title || '',
+      parentId: null,
+      sort: typeof c.sort === 'number' ? c.sort : undefined,
+    });
+  }
+  for (const c of childCollections || []) {
+    if (!c || c._id == null) continue;
+    const parentId =
+      (c.parent && (c.parent.$id != null ? c.parent.$id : c.parent)) || null;
+    byId.set(c._id, {
+      id: c._id,
+      title: c.title || '',
+      parentId,
+      sort: typeof c.sort === 'number' ? c.sort : undefined,
+    });
+  }
+  return byId;
+}
+
+export function buildCollectionToGroupMap(groups) {
+  const map = new Map();
+  for (const g of groups || []) {
+    const title = g && g.title ? g.title : '';
+    const ids = Array.isArray(g.collections) ? g.collections : [];
+    for (const id of ids) map.set(id, title);
+  }
+  return map;
+}
+
+export function computeGroupForCollection(
+  collectionId,
+  collectionsById,
+  rootCollectionToGroupTitle,
+) {
+  let currentId = collectionId;
+  const visited = new Set();
+  while (currentId != null && !visited.has(currentId)) {
+    visited.add(currentId);
+    const info = collectionsById.get(currentId);
+    if (!info) break;
+    if (info.parentId == null)
+      return rootCollectionToGroupTitle.get(info.id) || '';
+    currentId = info.parentId;
+  }
+  return '';
+}
+
+export function computeRootCollectionId(collectionId, collectionsById) {
+  let currentId = collectionId;
+  const visited = new Set();
+  while (currentId != null && !visited.has(currentId)) {
+    visited.add(currentId);
+    const info = collectionsById.get(currentId);
+    if (!info) return null;
+    if (info.parentId == null) return info.id;
+    currentId = info.parentId;
+  }
+  return null;
+}

--- a/src/modules/folder-sync.js
+++ b/src/modules/folder-sync.js
@@ -1,0 +1,224 @@
+// Ensure Chrome folders reflect Raindrop groups and collections
+import { chromeP } from './chrome.js';
+import {
+  ROOT_FOLDER_NAME,
+  UNSORTED_COLLECTION_ID,
+  getOrCreateRootFolder as bmGetOrCreateRootFolder,
+  getOrCreateChildFolder as bmGetOrCreateChildFolder,
+} from './bookmarks.js';
+import { loadState as loadStateFn, saveState as saveStateFn } from './state.js';
+import {
+  buildCollectionToGroupMap,
+  computeGroupForCollection,
+  computeRootCollectionId,
+} from './collections.js';
+
+export async function getOrCreateRootFolder() {
+  return bmGetOrCreateRootFolder(loadStateFn, saveStateFn);
+}
+
+export const getOrCreateChildFolder = bmGetOrCreateChildFolder;
+
+export async function syncFolders(groups, collectionsById, state) {
+  const rootFolderId = await getOrCreateRootFolder();
+  const groupMap = { ...(state.groupMap || {}) };
+  const collectionMap = { ...(state.collectionMap || {}) };
+  let didChange = false;
+  const SAVED_PROJECTS_TITLE = 'Saved Projects';
+
+  const currentGroupTitles = new Set();
+
+  try {
+    const prevUnsorted = collectionMap[String(UNSORTED_COLLECTION_ID)];
+    const unsortedId = await getOrCreateChildFolder(rootFolderId, 'Unsorted');
+    if (prevUnsorted !== unsortedId) didChange = true;
+    await chromeP.bookmarksMove(unsortedId, {
+      parentId: rootFolderId,
+      index: 0,
+    });
+    collectionMap[String(UNSORTED_COLLECTION_ID)] = unsortedId;
+  } catch (_) {}
+
+  for (const g of groups || []) {
+    const title = g.title || '';
+    if (title === SAVED_PROJECTS_TITLE) continue;
+    currentGroupTitles.add(title);
+    const folderId = await getOrCreateChildFolder(rootFolderId, title);
+    groupMap[title] = folderId;
+  }
+
+  for (const [title, folderId] of Object.entries(groupMap)) {
+    if (!currentGroupTitles.has(title) || title === SAVED_PROJECTS_TITLE) {
+      try {
+        await chromeP.bookmarksRemoveTree(folderId);
+      } catch (_) {}
+      delete groupMap[title];
+      didChange = true;
+    }
+  }
+
+  const rootCollectionToGroupTitle = buildCollectionToGroupMap(groups || []);
+
+  const allIds = Array.from(collectionsById.keys());
+  const depthMemo = new Map();
+  function depthOf(id) {
+    if (depthMemo.has(id)) return depthMemo.get(id);
+    const info = collectionsById.get(id);
+    if (!info) return 0;
+    const d = info.parentId == null ? 0 : 1 + depthOf(info.parentId);
+    depthMemo.set(id, d);
+    return d;
+  }
+  allIds.sort((a, b) => depthOf(a) - depthOf(b));
+
+  for (const id of allIds) {
+    const info = collectionsById.get(id);
+    if (!info) continue;
+    const desiredTitle = info.title || '';
+    let parentFolderId;
+    if (info.parentId == null) {
+      const groupTitle = rootCollectionToGroupTitle.get(id) || '';
+      parentFolderId = groupMap[groupTitle] || rootFolderId;
+    } else {
+      const rootId = computeRootCollectionId(id, collectionsById);
+      if (rootId == null) {
+        const existingFolderIdForChild = collectionMap[String(id)];
+        if (existingFolderIdForChild) {
+          try {
+            await chromeP.bookmarksRemoveTree(existingFolderIdForChild);
+          } catch (_) {}
+          delete collectionMap[String(id)];
+        }
+        continue;
+      }
+      const parentFolder = collectionMap[String(info.parentId)];
+      if (!parentFolder) {
+        const groupTitle =
+          computeGroupForCollection(
+            id,
+            collectionsById,
+            rootCollectionToGroupTitle,
+          ) || '';
+        parentFolderId = groupMap[groupTitle] || rootFolderId;
+      } else {
+        parentFolderId = parentFolder;
+      }
+    }
+
+    const existingFolderId = collectionMap[String(id)];
+    if (existingFolderId) {
+      try {
+        const nodes = await chromeP.bookmarksGet(existingFolderId);
+        const node = nodes && nodes[0];
+        if (node) {
+          if (node.title !== desiredTitle) {
+            await chromeP.bookmarksUpdate(existingFolderId, {
+              title: desiredTitle,
+            });
+            didChange = true;
+          }
+          if (node.parentId !== parentFolderId) {
+            await chromeP.bookmarksMove(existingFolderId, {
+              parentId: parentFolderId,
+            });
+            didChange = true;
+          }
+        } else {
+          const newNodeId = await getOrCreateChildFolder(
+            parentFolderId,
+            desiredTitle,
+          );
+          collectionMap[String(id)] = newNodeId;
+          didChange = true;
+        }
+      } catch (_) {
+        const newNodeId = await getOrCreateChildFolder(
+          parentFolderId,
+          desiredTitle,
+        );
+        collectionMap[String(id)] = newNodeId;
+        didChange = true;
+      }
+    } else {
+      const newNodeId = await getOrCreateChildFolder(
+        parentFolderId,
+        desiredTitle,
+      );
+      collectionMap[String(id)] = newNodeId;
+      didChange = true;
+    }
+  }
+
+  try {
+    for (const g of groups || []) {
+      const groupTitle = (g && g.title) || '';
+      const parentFolderId = groupMap[groupTitle];
+      if (!parentFolderId) continue;
+      const orderedRootIds = Array.isArray(g.collections) ? g.collections : [];
+      let position = 0;
+      for (const rootColId of orderedRootIds) {
+        const childFolderId = collectionMap[String(rootColId)];
+        if (!childFolderId) continue;
+        try {
+          await chromeP.bookmarksMove(childFolderId, {
+            parentId: parentFolderId,
+            index: position,
+          });
+          position += 1;
+        } catch (_) {}
+      }
+    }
+
+    const childrenByParent = new Map();
+    for (const info of collectionsById.values()) {
+      if (info && info.parentId != null) {
+        if (!childrenByParent.has(info.parentId))
+          childrenByParent.set(info.parentId, []);
+        childrenByParent
+          .get(info.parentId)
+          .push({ id: info.id, sort: info.sort });
+      }
+    }
+    for (const [parentCollectionId, children] of childrenByParent.entries()) {
+      const parentFolderId = collectionMap[String(parentCollectionId)];
+      if (!parentFolderId) continue;
+      const desiredOrder = children
+        .slice()
+        .sort((a, b) => {
+          const sa = typeof a.sort === 'number' ? a.sort : 0;
+          const sb = typeof b.sort === 'number' ? b.sort : 0;
+          return sa - sb;
+        })
+        .map((c) => c.id);
+      let idx = 0;
+      for (const childColId of desiredOrder) {
+        const childFolderId = collectionMap[String(childColId)];
+        if (!childFolderId) continue;
+        try {
+          await chromeP.bookmarksMove(childFolderId, {
+            parentId: parentFolderId,
+            index: idx,
+          });
+          idx += 1;
+        } catch (_) {}
+      }
+    }
+  } catch (_) {}
+
+  const currentIdSet = new Set(
+    Array.from(collectionsById.keys()).map((n) => String(n)),
+  );
+  for (const [colId, folderId] of Object.entries(collectionMap)) {
+    if (String(colId) === String(UNSORTED_COLLECTION_ID)) continue;
+    if (!currentIdSet.has(String(colId))) {
+      try {
+        await chromeP.bookmarksRemoveTree(folderId);
+      } catch (_) {}
+      delete collectionMap[colId];
+      didChange = true;
+    }
+  }
+
+  await saveStateFn({ groupMap, collectionMap, rootFolderId });
+  return { rootFolderId, groupMap, collectionMap, didChange };
+}

--- a/src/modules/item-sync.js
+++ b/src/modules/item-sync.js
@@ -210,6 +210,10 @@ export async function syncNewAndUpdatedItems(
 }
 
 export async function syncDeletedItems(lastSyncISO, itemMap, collectionMap) {
+  // Skip fetching trashed items on the initial sync
+  if (!lastSyncISO) {
+    return { itemMap, didChange: false };
+  }
   let page = 0;
   let stop = false;
   let didChange = false;

--- a/src/modules/item-sync.js
+++ b/src/modules/item-sync.js
@@ -1,0 +1,257 @@
+import { apiGET, apiPOST } from './api-facade.js';
+import { chromeP } from './chrome.js';
+import { UNSORTED_COLLECTION_ID } from './bookmarks.js';
+import { saveState as saveStateFn } from './state.js';
+
+export function extractCollectionId(item) {
+  if (item == null) return null;
+  if (item.collection && item.collection.$id != null)
+    return item.collection.$id;
+  if (item.collectionId != null) return item.collectionId;
+  if (item.collection && item.collection.id != null) return item.collection.id;
+  return null;
+}
+
+export async function ensureUnsortedFolder(
+  getOrCreateRootFolder,
+  getOrCreateChildFolder,
+  collectionMap,
+) {
+  const rootFolderId = await getOrCreateRootFolder();
+  if (collectionMap[String(UNSORTED_COLLECTION_ID)])
+    return collectionMap[String(UNSORTED_COLLECTION_ID)];
+  const folderId = await getOrCreateChildFolder(rootFolderId, 'Unsorted');
+  collectionMap[String(UNSORTED_COLLECTION_ID)] = folderId;
+  await saveStateFn({ collectionMap });
+  return folderId;
+}
+
+export async function syncNewAndUpdatedItems(
+  lastSyncISO,
+  collectionMap,
+  itemMap,
+  getOrCreateRootFolder,
+  getOrCreateChildFolder,
+) {
+  let maxLastUpdate = lastSyncISO ? new Date(lastSyncISO) : new Date(0);
+  let page = 0;
+  let stop = false;
+  const isInitial = !lastSyncISO;
+  const folderInsertionCount = new Map();
+  let didChange = false;
+
+  while (!stop) {
+    const res = await apiGET(
+      `/raindrops/0?sort=-lastUpdate&perpage=50&page=${page}`,
+    );
+    const items = Array.isArray(res.items) ? res.items : [];
+    for (const item of items) {
+      const itemLast = new Date(item.lastUpdate || item.lastupdate || 0);
+      if (lastSyncISO && itemLast <= new Date(lastSyncISO)) {
+        stop = true;
+        break;
+      }
+
+      const raindropId = String(item._id);
+      const collectionId = extractCollectionId(item);
+      const isUnsorted =
+        String(collectionId) === String(UNSORTED_COLLECTION_ID);
+      let targetFolderId = null;
+      let shouldSkipCreate = false;
+      if (isUnsorted) {
+        targetFolderId = await ensureUnsortedFolder(
+          getOrCreateRootFolder,
+          getOrCreateChildFolder,
+          collectionMap,
+        );
+      } else {
+        const mapped = collectionMap[String(collectionId)] || null;
+        if (mapped) {
+          try {
+            const nodes = await chromeP.bookmarksGet(mapped);
+            if (nodes && nodes.length) {
+              targetFolderId = mapped;
+            } else {
+              shouldSkipCreate = true;
+            }
+          } catch (_) {
+            shouldSkipCreate = true;
+          }
+        } else {
+          shouldSkipCreate = true;
+        }
+      }
+
+      if (itemMap[raindropId]) {
+        const localId = itemMap[raindropId];
+        try {
+          const nodes = await chromeP.bookmarksGet(localId);
+          const node = nodes && nodes[0];
+          if (node) {
+            if (
+              node.title !== (item.title || '') ||
+              node.url !== (item.link || item.url || '')
+            ) {
+              await chromeP.bookmarksUpdate(localId, {
+                title: item.title || '',
+                url: item.link || item.url || '',
+              });
+              didChange = true;
+            }
+            if (!shouldSkipCreate && targetFolderId) {
+              if (isInitial) {
+                if (node.parentId !== targetFolderId) {
+                  await chromeP.bookmarksMove(localId, {
+                    parentId: targetFolderId,
+                  });
+                  didChange = true;
+                }
+              } else {
+                const current = folderInsertionCount.get(targetFolderId) || 0;
+                folderInsertionCount.set(targetFolderId, current + 1);
+                await chromeP.bookmarksMove(localId, {
+                  parentId: targetFolderId,
+                  index: current,
+                });
+                didChange = true;
+              }
+            }
+          } else {
+            if (!shouldSkipCreate && targetFolderId) {
+              const createDetails = {
+                parentId: targetFolderId,
+                title: item.title || '',
+                url: item.link || item.url || '',
+              };
+              if (!isInitial) {
+                const current = folderInsertionCount.get(targetFolderId) || 0;
+                folderInsertionCount.set(targetFolderId, current + 1);
+                createDetails.index = current;
+              }
+              const newNode = await chromeP.bookmarksCreate(createDetails);
+              itemMap[raindropId] = newNode.id;
+              didChange = true;
+            }
+          }
+        } catch (e) {
+          if (isUnsorted) {
+            try {
+              targetFolderId = await ensureUnsortedFolder(
+                getOrCreateRootFolder,
+                getOrCreateChildFolder,
+                collectionMap,
+              );
+              const createDetails = {
+                parentId: targetFolderId,
+                title: item.title || '',
+                url: item.link || item.url || '',
+              };
+              if (!isInitial) {
+                const current = folderInsertionCount.get(targetFolderId) || 0;
+                folderInsertionCount.set(targetFolderId, current + 1);
+                createDetails.index = current;
+              }
+              const newNode = await chromeP.bookmarksCreate(createDetails);
+              itemMap[raindropId] = newNode.id;
+              didChange = true;
+            } catch (_) {}
+          }
+        }
+      } else {
+        if (!shouldSkipCreate && targetFolderId) {
+          try {
+            const createDetails = {
+              parentId: targetFolderId,
+              title: item.title || '',
+              url: item.link || item.url || '',
+            };
+            if (!isInitial) {
+              const current = folderInsertionCount.get(targetFolderId) || 0;
+              folderInsertionCount.set(targetFolderId, current + 1);
+              createDetails.index = current;
+            }
+            const newNode = await chromeP.bookmarksCreate(createDetails);
+            itemMap[raindropId] = newNode.id;
+            didChange = true;
+          } catch (e) {
+            if (isUnsorted) {
+              try {
+                targetFolderId = await ensureUnsortedFolder(
+                  getOrCreateRootFolder,
+                  getOrCreateChildFolder,
+                  collectionMap,
+                );
+                const createDetails = {
+                  parentId: targetFolderId,
+                  title: item.title || '',
+                  url: item.link || item.url || '',
+                };
+                if (!isInitial) {
+                  const current = folderInsertionCount.get(targetFolderId) || 0;
+                  folderInsertionCount.set(targetFolderId, current + 1);
+                  createDetails.index = current;
+                }
+                const newNode = await chromeP.bookmarksCreate(createDetails);
+                itemMap[raindropId] = newNode.id;
+                didChange = true;
+              } catch (_) {}
+            }
+          }
+        }
+      }
+
+      if (itemLast > maxLastUpdate) maxLastUpdate = itemLast;
+    }
+    if (stop || items.length < 50) break;
+    page += 1;
+  }
+
+  return { itemMap, newLastSyncISO: maxLastUpdate.toISOString(), didChange };
+}
+
+export async function syncDeletedItems(lastSyncISO, itemMap, collectionMap) {
+  let page = 0;
+  let stop = false;
+  let didChange = false;
+
+  while (!stop) {
+    const res = await apiGET(
+      `/raindrops/-99?sort=-lastUpdate&perpage=50&page=${page}`,
+    );
+    const items = Array.isArray(res.items) ? res.items : [];
+    for (const item of items) {
+      const itemLast = new Date(item.lastUpdate || item.lastupdate || 0);
+      if (lastSyncISO && itemLast <= new Date(lastSyncISO)) {
+        stop = true;
+        break;
+      }
+      const raindropId = String(item._id);
+      const localId = itemMap[raindropId];
+      if (localId) {
+        try {
+          await chromeP.bookmarksRemove(localId);
+        } catch (_) {}
+        delete itemMap[raindropId];
+        didChange = true;
+      } else {
+        const collectionId = extractCollectionId(item);
+        const folderId = collectionMap[String(collectionId)];
+        if (folderId) {
+          try {
+            const children = await chromeP.bookmarksGetChildren(folderId);
+            const found = children.find(
+              (c) => c.url && c.url === (item.link || item.url),
+            );
+            if (found) {
+              await chromeP.bookmarksRemove(found.id);
+              didChange = true;
+            }
+          } catch (_) {}
+        }
+      }
+    }
+    if (stop || items.length < 50) break;
+    page += 1;
+  }
+  return { itemMap, didChange };
+}

--- a/src/modules/mirror.js
+++ b/src/modules/mirror.js
@@ -1,0 +1,241 @@
+// Local Chrome bookmarks -> Raindrop mirroring handlers
+import { invertRecord } from './utils.js';
+import { UNSORTED_COLLECTION_ID } from './bookmarks.js';
+import { apiPOST, apiPUT, apiDELETE } from './api-facade.js';
+import { loadState, saveState } from './state.js';
+import {
+  recentlyCreatedRemoteUrls,
+  suppressLocalBookmarkEvents,
+} from './shared-state.js';
+
+export async function onCreated(id, node) {
+  const state = await loadState();
+  const rootFolderId = state.rootFolderId;
+  if (!rootFolderId) return;
+  // Only mirror changes under our managed root tree
+  const underRoot = await isUnderManagedRoot(node.parentId, rootFolderId);
+  if (!underRoot) return;
+
+  const collectionMap = { ...(state.collectionMap || {}) };
+  const collectionByFolder = invertRecord(collectionMap);
+  const unsortedFolderId = collectionMap[String(UNSORTED_COLLECTION_ID)] || '';
+
+  if (node.url) {
+    if (node && node.url && recentlyCreatedRemoteUrls.has(String(node.url)))
+      return;
+    let collectionId = null;
+    if (String(node.parentId) === String(unsortedFolderId)) {
+      collectionId = UNSORTED_COLLECTION_ID;
+    } else {
+      const mapped = collectionByFolder[String(node.parentId)];
+      collectionId = mapped != null ? Number(mapped) : UNSORTED_COLLECTION_ID;
+    }
+    const body = {
+      link: node.url,
+      title: node.title || node.url,
+      collection: { $id: collectionId },
+    };
+    try {
+      const res = await apiPOST('/raindrop', body);
+      const item = res && (res.item || res.data || res);
+      const newId =
+        item && (item._id != null ? String(item._id) : String(item.id || ''));
+      if (newId) {
+        const itemMap = { ...(state.itemMap || {}) };
+        itemMap[newId] = String(id);
+        await saveState({ itemMap });
+      }
+    } catch (_) {}
+  } else {
+    const parentCollectionId = await resolveParentCollectionId(
+      node.parentId,
+      state,
+    );
+    const body =
+      parentCollectionId == null
+        ? { title: node.title || '' }
+        : { title: node.title || '', parent: { $id: parentCollectionId } };
+    try {
+      const res = await apiPOST('/collection', body);
+      const created = res && (res.item || res.data || res);
+      const colId =
+        created &&
+        (created._id != null ? String(created._id) : String(created.id || ''));
+      if (colId) {
+        const newCollectionMap = { ...(state.collectionMap || {}) };
+        newCollectionMap[colId] = String(id);
+        await saveState({ collectionMap: newCollectionMap });
+      }
+    } catch (_) {}
+  }
+}
+
+export async function onRemoved(id) {
+  const state = await loadState();
+  if (state.rootFolderId) {
+    try {
+      const nodes = await chrome.bookmarks.get(String(state.rootFolderId));
+      if (!nodes || nodes.length === 0) return;
+    } catch (_) {
+      return;
+    }
+  }
+  const itemMap = { ...(state.itemMap || {}) };
+  const collectionMap = { ...(state.collectionMap || {}) };
+  const itemByLocal = invertRecord(itemMap);
+  const collectionByLocal = invertRecord(collectionMap);
+  if (itemByLocal[String(id)]) {
+    const raindropId = itemByLocal[String(id)];
+    try {
+      await apiDELETE(`/raindrop/${encodeURIComponent(raindropId)}`);
+    } catch (_) {}
+    delete itemMap[String(raindropId)];
+    await saveState({ itemMap });
+    return;
+  }
+  if (collectionByLocal[String(id)]) {
+    const collectionId = collectionByLocal[String(id)];
+    try {
+      await apiDELETE(`/collection/${encodeURIComponent(collectionId)}`);
+    } catch (_) {}
+    delete collectionMap[String(collectionId)];
+    await saveState({ collectionMap });
+  }
+}
+
+export async function onChanged(id, changeInfo) {
+  const state = await loadState();
+  const itemMap = { ...(state.itemMap || {}) };
+  const collectionMap = { ...(state.collectionMap || {}) };
+  const itemByLocal = invertRecord(itemMap);
+  const collectionByLocal = invertRecord(collectionMap);
+  if (itemByLocal[String(id)]) {
+    const raindropId = itemByLocal[String(id)];
+    const body = {};
+    if (typeof changeInfo.title === 'string') body['title'] = changeInfo.title;
+    if (typeof changeInfo.url === 'string') body['link'] = changeInfo.url;
+    if (Object.keys(body).length > 0) {
+      try {
+        await apiPUT(`/raindrop/${encodeURIComponent(raindropId)}`, body);
+      } catch (_) {}
+    }
+    return;
+  }
+  if (collectionByLocal[String(id)]) {
+    const collectionId = collectionByLocal[String(id)];
+    if (typeof changeInfo.title === 'string') {
+      try {
+        await apiPUT(`/collection/${encodeURIComponent(collectionId)}`, {
+          title: changeInfo.title,
+        });
+      } catch (_) {}
+    }
+  }
+}
+
+export async function onMoved(id, moveInfo, resolveParentCollectionId) {
+  const state = await loadState();
+  const rootFolderId = state.rootFolderId;
+  if (!rootFolderId) return;
+  const underRoot = await isUnderManagedRoot(moveInfo.parentId, rootFolderId);
+  if (!underRoot) return;
+  const itemMap = { ...(state.itemMap || {}) };
+  const collectionMap = { ...(state.collectionMap || {}) };
+  const groupMap = { ...(state.groupMap || {}) };
+  const itemByLocal = invertRecord(itemMap);
+  const collectionByLocal = invertRecord(collectionMap);
+  const unsortedFolderId = collectionMap[String(UNSORTED_COLLECTION_ID)] || '';
+  if (itemByLocal[String(id)]) {
+    const raindropId = itemByLocal[String(id)];
+    let newCollectionId = null;
+    if (String(moveInfo.parentId) === String(unsortedFolderId)) {
+      newCollectionId = UNSORTED_COLLECTION_ID;
+    } else {
+      const mapped = collectionByLocal[String(moveInfo.parentId)];
+      newCollectionId =
+        mapped != null ? Number(mapped) : UNSORTED_COLLECTION_ID;
+    }
+    try {
+      await apiPUT(`/raindrop/${encodeURIComponent(raindropId)}`, {
+        collection: { $id: newCollectionId },
+      });
+    } catch (_) {}
+    return;
+  }
+  if (collectionByLocal[String(id)]) {
+    const collectionId = collectionByLocal[String(id)];
+    let parentCollectionId = null;
+    const isParentGroup = Object.values(groupMap).some(
+      (gid) => String(gid) === String(moveInfo.parentId),
+    );
+    const isParentRoot = String(moveInfo.parentId) === String(rootFolderId);
+    if (
+      isParentGroup ||
+      isParentRoot ||
+      String(moveInfo.parentId) === String(unsortedFolderId)
+    ) {
+      parentCollectionId = null;
+    } else {
+      const mapped = collectionByLocal[String(moveInfo.parentId)];
+      parentCollectionId = mapped != null ? Number(mapped) : null;
+    }
+    const body =
+      parentCollectionId == null
+        ? { parent: null }
+        : { parent: { $id: parentCollectionId } };
+    try {
+      await apiPUT(`/collection/${encodeURIComponent(collectionId)}`, body);
+    } catch (_) {}
+  }
+}
+
+// Helpers shared in background originally
+export function invertRecord(record) {
+  const inverted = {};
+  for (const [k, v] of Object.entries(record || {})) {
+    if (v != null) inverted[String(v)] = String(k);
+  }
+  return inverted;
+}
+
+async function getAncestorIds(nodeId) {
+  const ids = [];
+  let currentId = nodeId;
+  const visited = new Set();
+  while (currentId && !visited.has(currentId)) {
+    visited.add(currentId);
+    ids.push(String(currentId));
+    try {
+      const nodes = await new Promise((resolve) =>
+        chrome.bookmarks.get(String(currentId), (n) => resolve(n)),
+      );
+      const node = nodes && nodes[0];
+      if (!node || !node.parentId) break;
+      currentId = node.parentId;
+    } catch (_) {
+      break;
+    }
+  }
+  return ids;
+}
+
+export async function isUnderManagedRoot(nodeId, rootFolderId) {
+  if (!nodeId || !rootFolderId) return false;
+  const ancestors = await getAncestorIds(nodeId);
+  return ancestors.includes(String(rootFolderId));
+}
+
+export async function resolveParentCollectionId(parentFolderId, state) {
+  const collectionMap = state.collectionMap || {};
+  const groupMap = state.groupMap || {};
+  const collectionByFolder = invertRecord(collectionMap);
+  const unsortedFolderId = collectionMap[String(UNSORTED_COLLECTION_ID)] || '';
+  const mapped = collectionByFolder[String(parentFolderId)];
+  if (mapped != null && mapped !== '') return Number(mapped);
+  if (String(parentFolderId) === String(unsortedFolderId)) return null;
+  for (const id of Object.values(groupMap || {})) {
+    if (String(id) === String(parentFolderId)) return null;
+  }
+  if (String(parentFolderId) === String(state.rootFolderId || '')) return null;
+  return null;
+}

--- a/src/modules/projects.js
+++ b/src/modules/projects.js
@@ -1,0 +1,577 @@
+import {
+  apiGET,
+  apiPOST,
+  apiPUT,
+  apiDELETE,
+  apiGETText,
+} from './api-facade.js';
+import { setBadge, scheduleClearBadge, notify } from './ui.js';
+import { loadState, saveState } from './state.js';
+import { ensureUnsortedFolder } from './item-sync.js';
+import {
+  getOrCreateRootFolder,
+  getOrCreateChildFolder,
+} from './folder-sync.js';
+import { rememberRecentlyCreatedRemoteUrls } from './shared-state.js';
+import {
+  windowSyncSessions,
+  persistActiveSyncSessions,
+} from './window-sync.js';
+import { chromeP } from './chrome.js';
+
+export async function listSavedProjects() {
+  const [userRes, rootsRes] = await Promise.all([
+    apiGET('/user'),
+    apiGET('/collections'),
+  ]);
+  const groups =
+    userRes && userRes.user && Array.isArray(userRes.user.groups)
+      ? userRes.user.groups
+      : [];
+  const saved = groups.find((g) => (g && g.title) === 'Saved Projects');
+  const order =
+    saved && Array.isArray(saved.collections) ? saved.collections : [];
+  const rootCollections = Array.isArray(rootsRes?.items) ? rootsRes.items : [];
+  const byId = new Map();
+  for (const c of rootCollections) {
+    if (c && c._id != null) byId.set(c._id, c);
+  }
+  const result = [];
+  for (const id of order) {
+    const c = byId.get(id);
+    if (!c) continue;
+    result.push({
+      id: c._id,
+      title: c.title || '',
+      count: c.count,
+      lastUpdate: c.lastUpdate,
+      cover: Array.isArray(c.cover) ? c.cover[0] || '' : c.cover || '',
+    });
+  }
+  return result;
+}
+
+export async function recoverSavedProject(chrome, collectionId) {
+  const colId = Number(collectionId);
+  if (!Number.isFinite(colId)) return;
+  // If already syncing with a window, focus that window
+  try {
+    let existingWinId = null;
+    for (const sess of windowSyncSessions.values()) {
+      if (sess && !sess.stopped && Number(sess.collectionId) === colId) {
+        existingWinId = sess.windowId;
+        break;
+      }
+    }
+    if (Number.isFinite(Number(existingWinId))) {
+      let existingWindow = null;
+      try {
+        existingWindow = await new Promise((resolve) =>
+          chrome.windows.get(Number(existingWinId), (w) => resolve(w)),
+        );
+      } catch (_) {}
+      if (existingWindow) {
+        try {
+          await chrome.windows.update(Number(existingWinId), { focused: true });
+        } catch (_) {}
+        return { focusedExisting: true, windowId: Number(existingWinId) };
+      } else {
+        try {
+          windowSyncSessions.delete(Number(existingWinId));
+          await persistActiveSyncSessions(chromeP);
+        } catch (_) {}
+      }
+    }
+  } catch (_) {}
+  const html = await apiGETText(`/raindrops/${colId}/export.html`);
+  try {
+    const items = [];
+    const linkRegex = /<DT>\s*<A\s+[^>]*HREF="([^"]+)"[^>]*>([\s\S]*?)<\/A>/gi;
+    const ddRegex = /<DD>\s*([\s\S]*?)(?=(?:<DT>|<\/DL>|$))/i;
+    let match;
+    while ((match = linkRegex.exec(html)) !== null) {
+      const url = match[1] ? match[1].trim() : '';
+      const rawTitle = match[2] || '';
+      const title = rawTitle
+        .replace(/\s+/g, ' ')
+        .replace(/<[^>]*>/g, '')
+        .trim();
+      const tail = html.slice(linkRegex.lastIndex);
+      const ddMatch = ddRegex.exec(tail);
+      let meta;
+      if (ddMatch && ddMatch[1]) {
+        const ddText = ddMatch[1]
+          .replace(/\n|\r/g, ' ')
+          .replace(/\s+/g, ' ')
+          .trim();
+        const normalized = ddText
+          .replace(/&quot;/g, '"')
+          .replace(/&#39;/g, "'");
+        try {
+          meta = JSON.parse(normalized);
+        } catch (_) {
+          meta = undefined;
+        }
+      }
+      items.push({ url, title, meta });
+    }
+    if (items.length === 0) throw new Error('No items found in export.html');
+    const sorted = items.sort(
+      (a, b) => (a.meta?.index ?? 0) - (b.meta?.index ?? 0),
+    );
+    const first = sorted[0];
+    const newWindow = await chrome.windows.create({
+      focused: true,
+      url: first.url,
+    });
+    if (!newWindow) throw new Error('Failed to create new window');
+    const [activeTab] = await chrome.tabs.query({
+      windowId: newWindow.id,
+      active: true,
+    });
+    if (activeTab && activeTab.id && (first.meta?.pinned ?? false)) {
+      try {
+        await chrome.tabs.update(activeTab.id, { pinned: true });
+      } catch (_) {}
+    }
+    const tabGroups = [];
+    if (activeTab && activeTab.id && first.meta?.tabGroup) {
+      tabGroups.push({
+        meta: {
+          tabGroup: first.meta?.tabGroup,
+          tabGroupColor: first.meta?.tabGroupColor,
+        },
+        tabIds: [activeTab.id],
+      });
+    }
+    for (const it of sorted.slice(1)) {
+      const newTab = await chrome.tabs.create({
+        url: it.url,
+        windowId: newWindow.id,
+        pinned: it.meta?.pinned ?? false,
+      });
+      if (newTab && newTab.id && it.meta?.tabGroup !== null) {
+        let group = tabGroups.find(
+          (g) => g.meta.tabGroup === it.meta?.tabGroup,
+        );
+        if (!group) {
+          group = {
+            meta: {
+              tabGroup: it.meta?.tabGroup,
+              tabGroupColor: it.meta?.tabGroupColor,
+            },
+            tabIds: [],
+          };
+          tabGroups.push(group);
+        }
+        group.tabIds.push(newTab.id);
+      }
+    }
+    for (const group of tabGroups) {
+      if (group.tabIds.length > 0) {
+        const tg = await chrome.tabs.group({ tabIds: group.tabIds });
+        if (tg) {
+          chrome.tabGroups.update(tg, {
+            title: group.meta.tabGroup,
+            color: group.meta.tabGroupColor,
+          });
+        }
+      }
+    }
+  } catch (e) {
+    console.error('Failed to parse export.html', e);
+  }
+}
+
+export async function deleteSavedProject(chromeP, collectionId) {
+  const colId = Number(collectionId);
+  if (!Number.isFinite(colId)) return;
+  setBadge('🗑️', '#ef4444');
+  try {
+    const [userRes, rootsRes] = await Promise.all([
+      apiGET('/user'),
+      apiGET('/collections'),
+    ]);
+    const groups = Array.isArray(userRes?.user?.groups)
+      ? userRes.user.groups
+      : [];
+    const idx = groups.findIndex((g) => (g && g.title) === 'Saved Projects');
+    if (idx >= 0) {
+      const newGroups = groups.slice();
+      const entry = {
+        ...(newGroups[idx] || { title: 'Saved Projects', collections: [] }),
+      };
+      const cols = Array.isArray(entry.collections)
+        ? entry.collections.slice()
+        : [];
+      entry.collections = cols.filter((cid) => Number(cid) !== colId);
+      try {
+        await apiPUT('/user', { groups: newGroups });
+      } catch (_) {}
+    }
+    const roots = Array.isArray(rootsRes?.items) ? rootsRes.items : [];
+    const existing = roots.find((c) => Number(c?._id) === colId);
+    const title = existing?.title || 'Project';
+    try {
+      await apiDELETE(`/collection/${encodeURIComponent(colId)}`);
+    } catch (_) {}
+    setBadge('✔️', '#22c55e');
+    scheduleClearBadge(3000);
+    try {
+      notify(`Deleted project "${title}"`);
+    } catch (_) {}
+  } catch (e) {
+    setBadge('😵', '#ef4444');
+    scheduleClearBadge(3000);
+    try {
+      notify(`Failed to delete project: ${e}`);
+    } catch (_) {}
+  }
+}
+
+export async function saveCurrentOrHighlightedTabsToRaindrop(chrome, chromeP) {
+  setBadge('⬆️', '#f59e0b');
+  let titlesAndUrls = [];
+  try {
+    const tabs = await new Promise((resolve) =>
+      chrome.tabs.query(
+        { windowId: chrome.windows.WINDOW_ID_CURRENT, highlighted: true },
+        (ts) => resolve(ts || []),
+      ),
+    );
+    let candidates =
+      Array.isArray(tabs) && tabs.length > 0
+        ? tabs
+        : await new Promise((resolve) =>
+            chrome.tabs.query({ active: true, currentWindow: true }, (ts) =>
+              resolve(ts || []),
+            ),
+          );
+    for (const t of candidates) {
+      const url = (t && t.url) || '';
+      if (url && (url.startsWith('https://') || url.startsWith('http://'))) {
+        titlesAndUrls.push({ title: (t && t.title) || url, url });
+      }
+    }
+    if (titlesAndUrls.length === 0)
+      throw new Error('No eligible tabs to save.');
+    const state = await loadState();
+    const collectionMap = { ...(state.collectionMap || {}) };
+    const unsortedFolderId = await ensureUnsortedFolder(
+      getOrCreateRootFolder,
+      getOrCreateChildFolder,
+      collectionMap,
+    );
+    const body = {
+      items: titlesAndUrls.map(({ title, url }) => ({
+        link: url,
+        title: title || url,
+        collection: { $id: -1 },
+        pleaseParse: {},
+      })),
+    };
+    const res = await apiPOST('/raindrops', body);
+    const createdItems = res && Array.isArray(res.items) ? res.items : [];
+    const successCount = createdItems.length;
+    const linkToId = new Map();
+    for (const it of createdItems) {
+      const link = it && (it.link || it.url);
+      const id =
+        it &&
+        (it._id != null ? String(it._id) : it.id != null ? String(it.id) : '');
+      if (link && id) linkToId.set(link, id);
+    }
+    const toCreateLocally = titlesAndUrls.map(({ title, url }) => ({
+      id: linkToId.get(url) || '',
+      title: title || url,
+      url,
+    }));
+    rememberRecentlyCreatedRemoteUrls(toCreateLocally.map(({ url }) => url));
+    const mergedItemMap = { ...((state && state.itemMap) || {}) };
+    for (const { id, title, url } of toCreateLocally.slice().reverse()) {
+      try {
+        const node = await chrome.bookmarks.create({
+          parentId: unsortedFolderId,
+          title: title || url,
+          url,
+          index: 0,
+        });
+        if (id) mergedItemMap[id] = node.id;
+      } catch (_) {}
+    }
+    try {
+      await saveState({ itemMap: mergedItemMap });
+    } catch (_) {}
+    if (successCount > 0) {
+      setBadge('✔️', '#22c55e');
+      scheduleClearBadge(3000);
+      try {
+        notify(
+          `Saved ${successCount} page${
+            successCount > 1 ? 's' : ''
+          } to Raindrop`,
+        );
+      } catch (_) {}
+    } else {
+      setBadge('😵', '#ef4444');
+      scheduleClearBadge(3000);
+      try {
+        notify('Failed to save tab(s) to Raindrop');
+      } catch (_) {}
+    }
+  } catch (err) {
+    setBadge('😵', '#ef4444');
+    scheduleClearBadge(3000);
+    try {
+      notify('Failed to save tab(s) to Raindrop');
+    } catch (_) {}
+  }
+}
+
+export async function saveHighlightedTabsAsProject(chrome, name) {
+  const projectName = String(name || '').trim();
+  if (!projectName) return;
+  let tabsList = await new Promise((resolve) =>
+    chrome.tabs.query(
+      { windowId: chrome.windows.WINDOW_ID_CURRENT, highlighted: true },
+      (ts) => resolve(ts || []),
+    ),
+  );
+  await saveTabsListAsProject(chrome, projectName, tabsList || []);
+}
+
+export async function saveTabsListAsProject(chrome, name, tabsList) {
+  setBadge('💾', '#a855f7');
+  try {
+    const eligibleTabs = (tabsList || []).filter(
+      (t) =>
+        t.url && (t.url.startsWith('https://') || t.url.startsWith('http://')),
+    );
+    if (!eligibleTabs.length) throw new Error('No eligible tabs');
+    const groupsInWindow = await new Promise((resolve) =>
+      chrome.tabGroups?.query(
+        { windowId: chrome.windows.WINDOW_ID_CURRENT },
+        (gs) => resolve(gs || []),
+      ),
+    );
+    const groupIdToMeta = new Map();
+    (groupsInWindow || []).slice().forEach((g) => {
+      groupIdToMeta.set(g.id, g);
+    });
+    const items = eligibleTabs.map((t, i) => {
+      const baseTitle = t.title || t.url || '';
+      const group = groupIdToMeta.get(t.groupId) || null;
+      const meta = {
+        index: i,
+        pinned: t.pinned,
+        tabGroup: group && group.title,
+        tabGroupColor: group && group.color,
+      };
+      return { link: t.url, title: baseTitle, note: JSON.stringify(meta) };
+    });
+    const userRes = await apiGET('/user');
+    const groups =
+      userRes && userRes.user && Array.isArray(userRes.user.groups)
+        ? userRes.user.groups
+        : [];
+    const savedProjectsTitle = 'Saved Projects';
+    let groupsArray = groups.slice();
+    let groupIndex = groupsArray.findIndex(
+      (g) => (g.title || '') === savedProjectsTitle,
+    );
+    if (groupIndex === -1) {
+      groupsArray = groupsArray.concat({
+        title: savedProjectsTitle,
+        hidden: false,
+        sort: groupsArray.length,
+        collections: [],
+      });
+      try {
+        await apiPUT('/user', { groups: groupsArray });
+      } catch (_) {}
+      try {
+        const uu = await apiGET('/user');
+        groupsArray =
+          uu && uu.user && Array.isArray(uu.user.groups)
+            ? uu.user.groups
+            : groupsArray;
+      } catch (_) {}
+      groupIndex = groupsArray.findIndex(
+        (g) => (g.title || '') === savedProjectsTitle,
+      );
+    }
+    const created = await apiPOST('/collection', { title: name });
+    const createdItem = created && (created.item || created.data || created);
+    const projectCollectionId =
+      createdItem && (createdItem._id ?? createdItem.id);
+    if (projectCollectionId == null)
+      throw new Error('Failed to create collection');
+    try {
+      const newGroups = groupsArray.slice();
+      const entry = {
+        ...(newGroups[groupIndex] || {
+          title: savedProjectsTitle,
+          collections: [],
+        }),
+      };
+      const cols = Array.isArray(entry.collections)
+        ? entry.collections.slice()
+        : [];
+      const filtered = cols.filter((cid) => cid !== projectCollectionId);
+      entry.collections = [projectCollectionId, ...filtered];
+      newGroups[groupIndex] = entry;
+      await apiPUT('/user', { groups: newGroups });
+    } catch (_) {}
+    const body = {
+      items: items.map((it) => ({
+        link: it.link,
+        title: it.title,
+        note: it.note,
+        collection: { $id: Number(projectCollectionId) },
+      })),
+    };
+    try {
+      await apiPOST('/raindrops', body);
+    } catch (_) {
+      for (const it of items) {
+        try {
+          await apiPOST('/raindrop', {
+            link: it.link,
+            title: it.title,
+            note: it.note,
+            collection: { $id: Number(projectCollectionId) },
+          });
+        } catch (_) {}
+      }
+    }
+    setBadge('✔️', '#22c55e');
+    scheduleClearBadge(3000);
+    try {
+      notify(
+        `Saved ${items.length} tab${
+          items.length > 1 ? 's' : ''
+        } to ${savedProjectsTitle}/${name}`,
+      );
+    } catch (_) {}
+  } catch (e) {
+    setBadge('😵', '#ef4444');
+    scheduleClearBadge(3000);
+    try {
+      notify(`Failed to save project: ${e}`);
+    } catch (_) {}
+  }
+}
+
+export async function replaceSavedProjectWithTabs(
+  chrome,
+  collectionId,
+  tabsList,
+) {
+  const oldId = Number(collectionId);
+  if (!Number.isFinite(oldId)) return { title: 'Project', count: 0 };
+  const eligibleTabs = (tabsList || []).filter(
+    (t) =>
+      t.url && (t.url.startsWith('https://') || t.url.startsWith('http://')),
+  );
+  if (eligibleTabs.length === 0) throw new Error('No eligible http(s) tabs');
+  const groupsInWindow = await new Promise((resolve) =>
+    chrome.tabGroups?.query(
+      { windowId: chrome.windows.WINDOW_ID_CURRENT },
+      (gs) => resolve(gs || []),
+    ),
+  );
+  const groupIdToMeta = new Map();
+  (groupsInWindow || []).forEach((g) => groupIdToMeta.set(g.id, g));
+  const items = eligibleTabs.map((t, i) => {
+    const baseTitle = t.title || t.url || '';
+    const group = groupIdToMeta.get(t.groupId) || null;
+    const meta = {
+      index: i,
+      pinned: t.pinned,
+      tabGroup: group && group.title,
+      tabGroupColor: group && group.color,
+    };
+    return { link: t.url, title: baseTitle, note: JSON.stringify(meta) };
+  });
+  const [userRes, rootsRes] = await Promise.all([
+    apiGET('/user'),
+    apiGET('/collections'),
+  ]);
+  const groups = Array.isArray(userRes?.user?.groups)
+    ? userRes.user.groups
+    : [];
+  const savedIdx = groups.findIndex((g) => (g && g.title) === 'Saved Projects');
+  const savedGroup = savedIdx >= 0 ? groups[savedIdx] : null;
+  const order = Array.isArray(savedGroup?.collections)
+    ? savedGroup.collections.slice()
+    : [];
+  const pos = order.findIndex((cid) => Number(cid) === oldId);
+  const roots = Array.isArray(rootsRes?.items) ? rootsRes.items : [];
+  const existing = roots.find((c) => Number(c?._id) === oldId);
+  const title = existing?.title || 'Project';
+  const existingCoverArray = Array.isArray(existing?.cover)
+    ? existing.cover.filter(Boolean)
+    : existing?.cover
+    ? [existing.cover]
+    : [];
+  const created = await apiPOST('/collection', { title });
+  const createdItem = created && (created.item || created.data || created);
+  const newId = createdItem && (createdItem._id ?? createdItem.id);
+  if (newId == null) throw new Error('Failed to create collection');
+  if (existingCoverArray.length > 0) {
+    try {
+      await apiPUT(`/collection/${encodeURIComponent(newId)}`, {
+        cover: existingCoverArray,
+      });
+    } catch (_) {}
+  }
+  try {
+    if (savedIdx >= 0) {
+      const newGroups = groups.slice();
+      const entry = {
+        ...(newGroups[savedIdx] || {
+          title: 'Saved Projects',
+          collections: [],
+        }),
+      };
+      const cols = Array.isArray(entry.collections)
+        ? entry.collections.slice()
+        : [];
+      if (pos >= 0) {
+        cols.splice(pos, 1, Number(newId));
+      } else {
+        const filtered = cols.filter((cid) => Number(cid) !== Number(newId));
+        filtered.unshift(Number(newId));
+        entry.collections = filtered;
+      }
+      if (pos >= 0) entry.collections = cols;
+      newGroups[savedIdx] = entry;
+      await apiPUT('/user', { groups: newGroups });
+    }
+  } catch (_) {}
+  try {
+    await apiPOST('/raindrops', {
+      items: items.map((it) => ({
+        link: it.link,
+        title: it.title,
+        note: it.note,
+        collection: { $id: Number(newId) },
+      })),
+    });
+  } catch (_) {
+    for (const it of items) {
+      try {
+        await apiPOST('/raindrop', {
+          link: it.link,
+          title: it.title,
+          note: it.note,
+          collection: { $id: Number(newId) },
+        });
+      } catch (_) {}
+    }
+  }
+  try {
+    await apiDELETE(`/collection/${encodeURIComponent(oldId)}`);
+  } catch (_) {}
+  return { title, count: items.length };
+}

--- a/src/modules/root-ensure.js
+++ b/src/modules/root-ensure.js
@@ -1,0 +1,46 @@
+import { chromeP } from './chrome.js';
+import { getBookmarksBarFolderId, ROOT_FOLDER_NAME } from './bookmarks.js';
+import { saveState as saveStateFn } from './state.js';
+
+export async function ensureRootAndMaybeReset(state) {
+  let rootExists = false;
+  let existingRootId = state && state.rootFolderId;
+  if (existingRootId) {
+    try {
+      const nodes = await chromeP.bookmarksGet(existingRootId);
+      if (nodes && nodes.length) rootExists = true;
+    } catch (_) {
+      rootExists = false;
+    }
+  }
+  if (rootExists) {
+    return { didReset: false, rootFolderId: String(existingRootId), state };
+  }
+
+  const barId = await getBookmarksBarFolderId();
+  let newRootId = null;
+  try {
+    const children = await chromeP.bookmarksGetChildren(barId);
+    const existing = children.find(
+      (c) => c && !c.url && (c.title || '') === ROOT_FOLDER_NAME,
+    );
+    if (existing) newRootId = existing.id;
+  } catch (_) {}
+  if (!newRootId) {
+    const node = await chromeP.bookmarksCreate({
+      parentId: barId,
+      title: ROOT_FOLDER_NAME,
+    });
+    newRootId = node.id;
+  }
+
+  const clearedState = {
+    lastSync: null,
+    collectionMap: {},
+    groupMap: {},
+    itemMap: {},
+    rootFolderId: newRootId,
+  };
+  await saveStateFn(clearedState);
+  return { didReset: true, rootFolderId: newRootId, state: clearedState };
+}

--- a/src/modules/shared-state.js
+++ b/src/modules/shared-state.js
@@ -1,0 +1,28 @@
+// Shared sync state and helpers used across modules
+
+/** Concurrency guard for full sync */
+export let isSyncing = false;
+export function setIsSyncing(value) {
+  isSyncing = Boolean(value);
+}
+
+/** Guard to suppress mirroring local bookmark events during extension-initiated changes */
+export let suppressLocalBookmarkEvents = false;
+export function setSuppressLocalBookmarkEvents(value) {
+  suppressLocalBookmarkEvents = Boolean(value);
+}
+
+// Track URLs we just created remotely (via bulk save) to prevent mirroring duplicates
+export const recentlyCreatedRemoteUrls = new Set();
+export function rememberRecentlyCreatedRemoteUrls(urls, ttlMs = 120000) {
+  for (const url of urls || []) {
+    if (!url) continue;
+    const key = String(url);
+    recentlyCreatedRemoteUrls.add(key);
+    setTimeout(() => {
+      try {
+        recentlyCreatedRemoteUrls.delete(key);
+      } catch (_) {}
+    }, Math.max(1000, Number(ttlMs) || 120000));
+  }
+}

--- a/src/modules/state.js
+++ b/src/modules/state.js
@@ -1,0 +1,38 @@
+import { chromeP } from './chrome.js';
+
+export const STORAGE_KEYS = {
+  lastSync: 'lastSync',
+  collectionMap: 'collectionMap',
+  groupMap: 'groupMap',
+  itemMap: 'itemMap',
+  rootFolderId: 'rootFolderId',
+};
+
+export async function loadState() {
+  const data = await chromeP.storageGet([
+    STORAGE_KEYS.lastSync,
+    STORAGE_KEYS.collectionMap,
+    STORAGE_KEYS.groupMap,
+    STORAGE_KEYS.itemMap,
+    STORAGE_KEYS.rootFolderId,
+  ]);
+  return {
+    lastSync: data[STORAGE_KEYS.lastSync] || null,
+    collectionMap: data[STORAGE_KEYS.collectionMap] || {},
+    groupMap: data[STORAGE_KEYS.groupMap] || {},
+    itemMap: data[STORAGE_KEYS.itemMap] || {},
+    rootFolderId: data[STORAGE_KEYS.rootFolderId] || null,
+  };
+}
+
+export async function saveState(partial) {
+  const toSave = {};
+  for (const [k, v] of Object.entries(partial || {})) {
+    if (k in STORAGE_KEYS) {
+      toSave[STORAGE_KEYS[k]] = v;
+    } else {
+      toSave[k] = v;
+    }
+  }
+  await chromeP.storageSet(toSave);
+}

--- a/src/modules/ui.js
+++ b/src/modules/ui.js
@@ -1,0 +1,49 @@
+// Action badge/title and notifications helpers
+import {
+  notify,
+  notifySyncFailure,
+  notifySyncSuccess,
+  TOKEN_NOTIFICATION_ID,
+  SYNC_SUCCESS_NOTIFICATION_ID,
+} from './notifications.js';
+
+export function setBadge(text, backgroundColor) {
+  try {
+    chrome.action?.setBadgeText({ text: text || '' });
+    if (backgroundColor) {
+      chrome.action?.setBadgeBackgroundColor({ color: backgroundColor });
+    }
+  } catch (_) {}
+}
+
+export function clearBadge() {
+  try {
+    chrome.action?.setBadgeText({ text: '' });
+  } catch (_) {}
+}
+
+export function scheduleClearBadge(delayMs) {
+  try {
+    chrome.alarms.clear('raindrop-clear-badge', () => {
+      try {
+        chrome.alarms.create('raindrop-clear-badge', {
+          when: Date.now() + Math.max(0, delayMs || 0),
+        });
+      } catch (_) {}
+    });
+  } catch (_) {}
+}
+
+export function setActionTitle(title) {
+  try {
+    chrome.action?.setTitle({ title: String(title || '') });
+  } catch (_) {}
+}
+
+export {
+  notify,
+  notifySyncFailure,
+  notifySyncSuccess,
+  TOKEN_NOTIFICATION_ID,
+  SYNC_SUCCESS_NOTIFICATION_ID,
+};

--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -1,0 +1,7 @@
+export function invertRecord(record) {
+  const inverted = {};
+  for (const [k, v] of Object.entries(record || {})) {
+    if (v != null) inverted[String(v)] = String(k);
+  }
+  return inverted;
+}

--- a/src/modules/window-sync.js
+++ b/src/modules/window-sync.js
@@ -1,0 +1,311 @@
+import {
+  setActionTitle,
+  setBadge,
+  scheduleClearBadge,
+  clearBadge,
+  notify,
+} from './ui.js';
+import {
+  apiGET,
+  apiPOST,
+  apiPUT,
+  apiDELETE,
+  apiGETText,
+} from './api-facade.js';
+
+export const ACTIVE_SYNC_SESSIONS_KEY = 'activeWindowSyncSessions';
+export const WINDOW_SYNC_ALARM_PREFIX = 'raindrop-window-sync-';
+
+/** @type {Map<number, { collectionId: number, windowId: number, name: string, stopped?: boolean }>} */
+export const windowSyncSessions = new Map();
+
+export function projectNameWithoutPrefix(name) {
+  const s = String(name || '');
+  return s.replace(/^\s*⏫?\s+/, '');
+}
+
+export async function persistActiveSyncSessions(chromeP) {
+  const obj = {};
+  for (const [winId, sess] of windowSyncSessions.entries()) {
+    obj[String(winId)] = { collectionId: sess.collectionId, name: sess.name };
+  }
+  try {
+    await chromeP.storageSet({ [ACTIVE_SYNC_SESSIONS_KEY]: obj });
+  } catch (_) {}
+}
+
+export async function loadActiveSyncSessionsIntoMemory(chromeP) {
+  try {
+    const data = await chromeP.storageGet(ACTIVE_SYNC_SESSIONS_KEY);
+    const saved = data && data[ACTIVE_SYNC_SESSIONS_KEY];
+    const obj = saved && typeof saved === 'object' ? saved : {};
+    windowSyncSessions.clear();
+    for (const [k, v] of Object.entries(obj)) {
+      const winId = Number(k);
+      const collectionId = Number(v && v.collectionId);
+      const name = String(v && v.name) || '';
+      if (!Number.isFinite(winId) || !Number.isFinite(collectionId)) continue;
+      windowSyncSessions.set(winId, { collectionId, windowId: winId, name });
+    }
+  } catch (_) {}
+}
+
+export function scheduleWindowSync(chrome, windowId, timeoutMs = 1500) {
+  const sess = windowSyncSessions.get(Number(windowId));
+  if (!sess || sess.stopped) return;
+  const name = `${WINDOW_SYNC_ALARM_PREFIX}${Number(windowId)}`;
+  try {
+    chrome.alarms.clear(name, () => {
+      try {
+        chrome.alarms.create(name, {
+          when: Date.now() + Math.max(300, Number(timeoutMs) || 1500),
+        });
+      } catch (_) {}
+    });
+  } catch (_) {}
+}
+
+export function stopWindowSync(chrome, windowId) {
+  const sess = windowSyncSessions.get(Number(windowId));
+  if (!sess) return;
+  sess.stopped = true;
+  try {
+    chrome.alarms.clear(`${WINDOW_SYNC_ALARM_PREFIX}${Number(windowId)}`);
+  } catch (_) {}
+  windowSyncSessions.delete(Number(windowId));
+}
+
+export async function restoreActionUiForActiveWindow(chrome, chromeP) {
+  try {
+    let winId = null;
+    try {
+      const tabs = await new Promise((resolve) =>
+        chrome.tabs.query({ active: true, lastFocusedWindow: true }, (ts) =>
+          resolve(ts || []),
+        ),
+      );
+      const t = Array.isArray(tabs) && tabs.length ? tabs[0] : null;
+      if (t && t.windowId != null) winId = Number(t.windowId);
+    } catch (_) {}
+    if (!Number.isFinite(winId)) {
+      try {
+        const w = await new Promise((resolve) =>
+          chrome.windows.getLastFocused({ windowTypes: ['normal'] }, (ww) =>
+            resolve(ww || null),
+          ),
+        );
+        if (w && w.id != null) winId = Number(w.id);
+      } catch (_) {}
+    }
+    let currentBadge = '';
+    try {
+      currentBadge = await new Promise((resolve) =>
+        chrome.action?.getBadgeText({}, (text) => resolve(text || '')),
+      );
+    } catch (_) {}
+    const sess = windowSyncSessions.get(Number(winId));
+    if (sess && !sess.stopped) {
+      const wants = '⏫';
+      if (!currentBadge || currentBadge === wants) {
+        setBadge(wants, '#38bdf8');
+      }
+      const pn = projectNameWithoutPrefix(sess.name || '');
+      setActionTitle(
+        pn
+          ? `Tabs in this window are syncing to ${pn}`
+          : 'This window is syncing to a Saved Project',
+      );
+    } else {
+      setActionTitle('Raindrop Bear');
+      if (currentBadge === '⏫') {
+        setBadge('');
+      }
+    }
+  } catch (_) {}
+}
+
+export async function startSyncCurrentWindowAsProject(
+  chrome,
+  chromeP,
+  projectName,
+  windowId,
+) {
+  const rawName = String(projectName || '').trim();
+  if (!rawName || !Number.isFinite(Number(windowId))) return;
+  const syncTitle = `⏫ ${rawName}`;
+  setBadge('🔄', '#6366f1');
+  try {
+    const pn = projectNameWithoutPrefix(syncTitle);
+    setActionTitle(
+      pn
+        ? `Tabs in this window are syncing to ${pn}`
+        : 'This window is syncing to a Saved Project',
+    );
+  } catch (_) {}
+  try {
+    const collectionId = await createCollectionUnderSavedProjects(syncTitle);
+    await overrideCollectionWithWindowTabs(
+      chrome,
+      Number(collectionId),
+      Number(windowId),
+    );
+    windowSyncSessions.set(Number(windowId), {
+      collectionId: Number(collectionId),
+      windowId: Number(windowId),
+      name: syncTitle,
+    });
+    await persistActiveSyncSessions(chromeP);
+    setBadge('✔️', '#22c55e');
+    scheduleClearBadge(2000);
+    try {
+      await restoreActionUiForActiveWindow(chrome, chromeP);
+    } catch (_) {}
+    try {
+      notify(`Sync started: ${syncTitle}`);
+    } catch (_) {}
+  } catch (e) {
+    setBadge('😵', '#ef4444');
+    scheduleClearBadge(3000);
+    try {
+      notify(`Failed to start sync: ${e}`);
+    } catch (_) {}
+    try {
+      await restoreActionUiForActiveWindow(chrome, chromeP);
+    } catch (_) {}
+  }
+}
+
+export async function startSyncWindowToExistingProject(
+  chromeP,
+  collectionId,
+  projectName,
+  windowId,
+) {
+  const colId = Number(collectionId);
+  const winId = Number(windowId);
+  if (!Number.isFinite(colId) || !Number.isFinite(winId)) return;
+  const name = String(projectName || '');
+  try {
+    windowSyncSessions.set(winId, {
+      collectionId: colId,
+      windowId: winId,
+      name,
+    });
+    await persistActiveSyncSessions(chromeP);
+  } catch (_) {}
+}
+
+export async function createCollectionUnderSavedProjects(title) {
+  const userRes = await apiGET('/user');
+  const groups = Array.isArray(userRes?.user?.groups)
+    ? userRes.user.groups
+    : [];
+  const savedTitle = 'Saved Projects';
+  let groupsArray = groups.slice();
+  let idx = groupsArray.findIndex((g) => (g && g.title) === savedTitle);
+  if (idx === -1) {
+    groupsArray = groupsArray.concat({
+      title: savedTitle,
+      hidden: false,
+      sort: groupsArray.length,
+      collections: [],
+    });
+    try {
+      await apiPUT('/user', { groups: groupsArray });
+    } catch (_) {}
+    try {
+      const uu = await apiGET('/user');
+      groupsArray = Array.isArray(uu?.user?.groups)
+        ? uu.user.groups
+        : groupsArray;
+    } catch (_) {}
+    idx = groupsArray.findIndex((g) => (g && g.title) === savedTitle);
+  }
+  const created = await apiPOST('/collection', { title });
+  const createdItem = created && (created.item || created.data || created);
+  const collectionId = createdItem && (createdItem._id ?? createdItem.id);
+  if (collectionId == null) throw new Error('Failed to create collection');
+  try {
+    const newGroups = groupsArray.slice();
+    const entry = {
+      ...(newGroups[idx] || { title: savedTitle, collections: [] }),
+    };
+    const cols = Array.isArray(entry.collections)
+      ? entry.collections.slice()
+      : [];
+    const filtered = cols.filter((cid) => Number(cid) !== Number(collectionId));
+    entry.collections = [Number(collectionId), ...filtered];
+    newGroups[idx] = entry;
+    await apiPUT('/user', { groups: newGroups });
+  } catch (_) {}
+  return Number(collectionId);
+}
+
+export async function buildItemsFromWindowTabs(chrome, windowId) {
+  const tabsList = await new Promise((resolve) =>
+    chrome.tabs.query({ windowId: Number(windowId) }, (ts) =>
+      resolve(ts || []),
+    ),
+  );
+  const groupsInWindow = await new Promise((resolve) =>
+    chrome.tabGroups?.query({ windowId: Number(windowId) }, (gs) =>
+      resolve(gs || []),
+    ),
+  );
+  const groupMap = new Map();
+  (groupsInWindow || []).forEach((g) => groupMap.set(g.id, g));
+  const eligible = (tabsList || []).filter(
+    (t) =>
+      t.url && (t.url.startsWith('https://') || t.url.startsWith('http://')),
+  );
+  return eligible.map((t, i) => {
+    const baseTitle = t.title || t.url || '';
+    const group = groupMap.get(t.groupId) || null;
+    const meta = {
+      index: i,
+      pinned: t.pinned,
+      tabGroup: group && group.title,
+      tabGroupColor: group && group.color,
+    };
+    return { link: t.url, title: baseTitle, note: JSON.stringify(meta) };
+  });
+}
+
+export async function overrideCollectionWithWindowTabs(
+  chrome,
+  collectionId,
+  windowId,
+) {
+  try {
+    await apiGET(`/collection/${encodeURIComponent(Number(collectionId))}`);
+  } catch (e) {
+    stopWindowSync(chrome, windowId);
+    throw e;
+  }
+  const itemsToSave = await buildItemsFromWindowTabs(chrome, windowId);
+  if (itemsToSave.length === 0) return;
+  try {
+    await apiDELETE(`/raindrops/${encodeURIComponent(Number(collectionId))}`);
+  } catch (_) {}
+  try {
+    await apiPOST('/raindrops', {
+      items: itemsToSave.map((it) => ({
+        link: it.link,
+        title: it.title,
+        note: it.note,
+        collection: { $id: Number(collectionId) },
+      })),
+    });
+  } catch (_) {
+    for (const it of itemsToSave) {
+      try {
+        await apiPOST('/raindrop', {
+          link: it.link,
+          title: it.title,
+          note: it.note,
+          collection: { $id: Number(collectionId) },
+        });
+      } catch (_) {}
+    }
+  }
+}

--- a/src/popup.html
+++ b/src/popup.html
@@ -29,19 +29,23 @@
     <div class="flex flex-col">
       <button id="sync-btn"
         class="inline-flex items-center bg-blue-500 px-4 py-2 text-white shadow-sm transition cursor-pointer hover:bg-black hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60">
-        🔄 Sync bookmarks
+        📑 Sync bookmarks
       </button>
       <button id="save-btn"
         class="inline-flex items-center bg-green-500 px-4 py-2 text-white shadow-sm transition cursor-pointer hover:bg-black hover:text-white focus:outline-none focus:ring-2 focus:ring-green-500 disabled:opacity-60">
-        ⬆️ Save to unsorted
+        📥 Save to unsorted
       </button>
       <button id="save-project-btn"
         class="inline-flex items-center bg-orange-400 px-4 py-2 text-white shadow-sm transition cursor-pointer hover:bg-black hover:text-white focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:opacity-60">
-        💾 Save as project
+        🔼 Save as project
       </button>
       <button id="save-window-project-btn"
         class="inline-flex items-center bg-orange-500 px-4 py-2 text-white shadow-sm transition cursor-pointer hover:bg-black hover:text-white focus:outline-none focus:ring-2 focus:ring-orange-400 disabled:opacity-60">
-        💾 Save current window as project
+        ⏫ Save current window as project
+      </button>
+      <button id="sync-window-project-btn"
+        class="inline-flex items-center bg-red-500 px-4 py-2 text-white shadow-sm transition cursor-pointer hover:bg-black hover:text-white focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-60">
+        🔄️ Sync current window as project
       </button>
     </div>
 

--- a/src/popup.html
+++ b/src/popup.html
@@ -39,13 +39,9 @@
         class="inline-flex items-center bg-orange-400 px-4 py-2 text-white shadow-sm transition cursor-pointer hover:bg-black hover:text-white focus:outline-none focus:ring-2 focus:ring-orange-500 disabled:opacity-60">
         🔼 Save as project
       </button>
-      <button id="save-window-project-btn"
-        class="inline-flex items-center bg-orange-500 px-4 py-2 text-white shadow-sm transition cursor-pointer hover:bg-black hover:text-white focus:outline-none focus:ring-2 focus:ring-orange-400 disabled:opacity-60">
-        ⏫ Save current window as project
-      </button>
       <button id="sync-window-project-btn"
         class="inline-flex items-center bg-red-500 px-4 py-2 text-white shadow-sm transition cursor-pointer hover:bg-black hover:text-white focus:outline-none focus:ring-2 focus:ring-red-400 disabled:opacity-60">
-        🔄️ Sync current window as project
+        ⏫ Sync current window as project
       </button>
     </div>
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -8,9 +8,6 @@
   const saveProjectBtn = /** @type {HTMLButtonElement|null} */ (
     document.getElementById('save-project-btn')
   );
-  const saveWindowProjectBtn = /** @type {HTMLButtonElement|null} */ (
-    document.getElementById('save-window-project-btn')
-  );
   const syncWindowProjectBtn = /** @type {HTMLButtonElement|null} */ (
     document.getElementById('sync-window-project-btn')
   );
@@ -25,7 +22,6 @@
     !(syncBtn instanceof HTMLButtonElement) ||
     !(saveBtn instanceof HTMLButtonElement) ||
     !(saveProjectBtn instanceof HTMLButtonElement) ||
-    !(saveWindowProjectBtn instanceof HTMLButtonElement) ||
     !(syncWindowProjectBtn instanceof HTMLButtonElement)
   )
     return;
@@ -135,8 +131,7 @@
       count === 1 ? '📥 Save to unsorted' : `📥 Save ${count} tabs to unsorted`;
     saveProjectBtn.textContent =
       count === 1 ? '🔼 Save as project' : `🔼 Save ${count} tabs as project`;
-    saveWindowProjectBtn.textContent = '⏫ Save current window as project';
-    syncWindowProjectBtn.textContent = '🔄️ Sync current window as project';
+    syncWindowProjectBtn.textContent = '⏫ Sync current window as project';
 
     // Load saved projects list
     try {
@@ -198,52 +193,6 @@
             const right = document.createElement('div');
             right.className = 'flex items-center gap-1';
 
-            const replaceWithCurrentWindowBtn =
-              document.createElement('button');
-            replaceWithCurrentWindowBtn.type = 'button';
-            replaceWithCurrentWindowBtn.title =
-              'Replace with current window tabs';
-            replaceWithCurrentWindowBtn.textContent = '⏫';
-            replaceWithCurrentWindowBtn.className =
-              'p-1 text-xs rounded bg-transparent transition-colors hover:bg-black cursor-pointer';
-            replaceWithCurrentWindowBtn.addEventListener('click', async (e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const ok = confirm(
-                `Replace saved project "${String(
-                  it.title || 'Untitled',
-                )}" with current window tabs?`,
-              );
-              if (!ok) return;
-              disableAllButtons();
-              setStatus('Replacing…');
-              await sendCommand('replaceSavedProjectWithCurrentWindowTabs', {
-                id: it.id,
-              });
-              window.close();
-            });
-
-            const replaceWithSelectedTabsBtn = document.createElement('button');
-            replaceWithSelectedTabsBtn.type = 'button';
-            replaceWithSelectedTabsBtn.title = 'Replace with selected tabs';
-            replaceWithSelectedTabsBtn.textContent = '🔼';
-            replaceWithSelectedTabsBtn.className =
-              'p-1 text-xs rounded bg-transparent transition-colors hover:bg-black cursor-pointer';
-            replaceWithSelectedTabsBtn.addEventListener('click', async (e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              const ok = confirm(
-                `Replace saved project "${String(
-                  it.title || 'Untitled',
-                )}" with selected tabs?`,
-              );
-              if (!ok) return;
-              disableAllButtons();
-              setStatus('Replacing…');
-              await sendCommand('replaceSavedProject', { id: it.id });
-              window.close();
-            });
-
             const deleteBtn = document.createElement('button');
             deleteBtn.type = 'button';
             deleteBtn.title = 'Delete';
@@ -264,14 +213,10 @@
             });
 
             function disableAllButtons() {
-              replaceWithCurrentWindowBtn.disabled = true;
-              replaceWithSelectedTabsBtn.disabled = true;
               deleteBtn.disabled = true;
               li.classList.add('opacity-60');
             }
 
-            right.appendChild(replaceWithCurrentWindowBtn);
-            right.appendChild(replaceWithSelectedTabsBtn);
             right.appendChild(deleteBtn);
 
             li.appendChild(left);
@@ -313,23 +258,6 @@
     }
     setStatus('');
     saveProjectBtn.disabled = false;
-    window.close();
-  });
-
-  saveWindowProjectBtn.addEventListener('click', async () => {
-    saveWindowProjectBtn.disabled = true;
-    setStatus('Saving');
-    const suggested = await computeSuggestedProjectName({
-      highlightedOnly: false,
-    });
-    const name = prompt('Project name?', suggested || undefined);
-    if (name && name.trim()) {
-      await sendCommand('saveCurrentWindowAsProject', {
-        name: name.trim(),
-      });
-    }
-    setStatus('');
-    saveWindowProjectBtn.disabled = false;
     window.close();
   });
 


### PR DESCRIPTION
### Summary

This PR splits `background.js` into focused modules, changes bookmark mirroring to **one-way (Raindrop → local)**, and introduces a **live “sync current window as project”** workflow. It also refreshes the popup UI text/icons and adds architecture docs.&#x20;

### What’s changed

* 🧩 **Architecture**

  * Extract major logic from `src/background.js` into modules:

    * `collections.js`, `folder-sync.js`, `item-sync.js`, `window-sync.js`, `projects.js`, `mirror.js`, `ui.js`, `state.js`, `api-facade.js`, etc.
  * Add `docs/ARCHITECTURE.md` explaining module responsibilities and flows.
* 🔁 **Sync model**

  * Switch from two-way to **one-way mirroring** (Raindrop → local). Local edits aren’t mirrored back (except optional mirror utilities kept separate).
* ⏫ **Live window→project sync**

  * New action: **“Sync current window as project (live)”** that keeps a Saved Project in sync with the active window until stopped.
  * Persist/restore session state; badge/title reflect sync state.
* 🧼 **Saved Projects scope simplified**

  * Remove “save/replace with current window/selected tabs” flows in favor of:

    * Save **highlighted tabs** as a project.
    * Live sync for the **current window**.
* 🪟 **Recovery UX**

  * When recovering a project, focus an already-synced window instead of opening duplicates.
* 🧭 **UI copy & icons**

  * Tweak popup labels/emojis; clearer action titles; success/error badge handling.
* 📚 **Docs**

  * Update `README.md` and `docs/STORE.md` to reflect one-way sync + new toolbar actions.

### Files / stats

* 9 commits • 18 files changed
* `src/background.js`: net −1.6k lines (moved into modules)
* New: `docs/ARCHITECTURE.md` (+217 lines) and multiple `src/modules/*` files.&#x20;

### Rationale

* Reduce `background.js` complexity, make features testable and easier to evolve.
* Eliminate duplication issues from previous two-way mirroring.
* Provide a clearer mental model for users: highlight-to-save or window-to-project live sync.

### Breaking/behavior changes

* ⚠️ **No more two-way sync** under the managed `Raindrop` folder.
* ⚠️ **“Replace project with current window/selected tabs”** buttons removed from the popup.

### Testing notes

* ✅ Fresh install: authorize token, run manual sync, verify Raindrop→local mirroring.
* ✅ Popup:

  * “Save as project” works for highlighted tabs.
  * “⏫ Sync current window as project” creates/updates the project; badge/title update; session persists across worker restarts.
* ✅ Recovering a project focuses an existing synced window when present.