### PR TITLE
Options page: merge Sessions UI; add parent-folder select helper with debounced bookmark refresh

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -74,12 +74,11 @@
       <div class="mt-2">
         <span id="parent-folder-status" class="text-sm"></span>
       </div>
-    </section>
 
-    <section
-      class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-6 dark:border-gray-800 dark:bg-gray-900">
+      <hr class="my-6 border-gray-200 dark:border-gray-800" />
+
       <div class="mb-4">
-        <h2 class="text-xl text-base/6 font-medium">📣 Notifications</h2>
+        <h3 class="text-lg font-medium">📣 Notifications</h3>
         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
           Control whether a notification is shown after each sync (success or failure).
         </p>
@@ -109,12 +108,11 @@
         </button>
       </div>
       <div id="duplicates-container" class="mt-4"></div>
-    </section>
 
-    <section
-      class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-6 dark:border-gray-800 dark:bg-gray-900">
+      <hr class="my-6 border-gray-200 dark:border-gray-800" />
+
       <div class="mb-4">
-        <h2 class="text-xl text-base/6 font-medium">🔄 Force Full Sync</h2>
+        <h3 class="text-lg font-medium">🔄 Force Full Sync</h3>
         <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
           If you're having issues, you can delete the local Raindrop folder and perform a full
           download sync.


### PR DESCRIPTION
**Summary**

* 🧩 Refactors options page to centralize “parent folder” select logic and smooth out folder refreshes.
* ⚙️ Minor UI tidy-ups to headings/separators on the page.&#x20;

**What’s changed**

* 🧠 Added `populateParentFolders(preferredId)` to build the parent-folder `<select>`, defaulting to Bookmarks Bar and preserving the prior selection if available.&#x20;
* ⏱️ Introduced a 200ms debounced refresh when bookmark tree changes (`onCreated/Removed/Moved/Changed` and `onChildrenReordered`) to keep the list current without flicker.&#x20;
* 🧹 Replaced ad-hoc folder-population code with the new helper during init.&#x20;
* 🖼️ UI tweaks in `options.html`: inserted horizontal rules between sections; downgraded section headings (Notifications / Force Full Sync) from `h2` → `h3` for better hierarchy.&#x20;

**Why**

* ✅ Improves UX by keeping the folder list accurate while avoiding jank.
* ✅ Simplifies maintenance via a single, tested helper.

**How to test**

* 🔌 Open the Options page; confirm the parent-folder list is populated and defaults sensibly.
* ➕ Create/rename/move/delete bookmark folders; verify the list updates smoothly and preserves selection.
* 🔄 Change selection; reload page and confirm the saved selection is restored.

**Risks / notes**

* ⚠️ Relies on `chrome.bookmarks.*` events; tested to be idempotent if listeners are added multiple times.&#x20;