### PR TITLE
Update parent folder note to be instructional and consistent

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -62,8 +62,8 @@
       class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm mt-6 dark:border-gray-800 dark:bg-gray-900">
       <div class="mb-4">
         <h2 class="text-xl text-base/6 font-medium">📂 Parent Folder</h2>
-        <p class="mt-1 text-sm text-gray-600 dark:text-gray-400">
-          Choose the parent bookmark folder for the Raindrop folder.
+        <p id="parent-folder-description" class="mt-1 text-sm text-gray-600 dark:text-gray-400">
+          Choose the parent bookmark folder. A "Raindrop" subfolder will be created.
         </p>
       </div>
       <div class="flex items-center justify-between gap-3">

--- a/src/options.js
+++ b/src/options.js
@@ -3,6 +3,7 @@ import { fetchGroupsAndCollections } from './modules/collections.js';
 import {
   getAllBookmarkFolders,
   getBookmarksBarFolderId,
+  ROOT_FOLDER_NAME,
 } from './modules/bookmarks.js';
 import { chromeP } from './modules/chrome.js';
 import { loadState, saveState } from './modules/state.js';
@@ -32,6 +33,9 @@ import { loadState, saveState } from './modules/state.js';
   );
   const parentFolderStatusEl = /** @type {HTMLSpanElement|null} */ (
     document.getElementById('parent-folder-status')
+  );
+  const parentFolderDescriptionEl = /** @type {HTMLParagraphElement|null} */ (
+    document.getElementById('parent-folder-description')
   );
 
   // --- new: helper to populate parent folder select ---
@@ -100,6 +104,9 @@ import { loadState, saveState } from './modules/state.js';
   }
 
   async function load() {
+    if (parentFolderDescriptionEl) {
+      parentFolderDescriptionEl.textContent = `Choose the parent bookmark folder. A "${ROOT_FOLDER_NAME}" subfolder will be created.`;
+    }
     try {
       const data = await chromeP.storageGet([
         'raindropApiToken',


### PR DESCRIPTION
The note for choosing the parent bookmark folder has been updated to be more instructional and to use the word 'subfolder'.

The static text in options.html has been made consistent with the dynamic text in options.js